### PR TITLE
Feat/centralize url handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
-# Static Environment Variables
-NEXT_PUBLIC_BASE_URL=http://localhost:3000
-BASE_URL=http://localhost:3000
 # Used to redirect to /dashboard after sign in
 CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/dashboard
 

--- a/lib/payments/stripe.ts
+++ b/lib/payments/stripe.ts
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { User } from "@/lib/db/schema";
 import { updateUserSubscription } from "@/lib/db/queries";
 import { auth, currentUser } from "@clerk/nextjs/server";
+import { baseUrl } from "@/lib/utils-server";
 
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2024-06-20",
@@ -29,8 +30,8 @@ export async function createCheckoutSession({
       },
     ],
     mode: "subscription",
-    success_url: `${process.env.BASE_URL}/api/stripe/checkout?session_id={CHECKOUT_SESSION_ID}`,
-    cancel_url: `${process.env.BASE_URL}/pricing`,
+    success_url: `${baseUrl()}/api/stripe/checkout?session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${baseUrl()}/pricing`,
     customer: user.stripeCustomerId || undefined,
     client_reference_id: user.id.toString(),
     allow_promotion_codes: true,
@@ -102,7 +103,7 @@ export async function createCustomerPortalSession(user: User) {
 
   return stripe.billingPortal.sessions.create({
     customer: user.stripeCustomerId,
-    return_url: `${process.env.BASE_URL}/dashboard`,
+    return_url: `${baseUrl()}/dashboard`,
     configuration: configuration.id,
   });
 }

--- a/lib/setup.ts
+++ b/lib/setup.ts
@@ -290,13 +290,9 @@ async function main() {
   const { publishableKey: NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY, secretKey: CLERK_SECRET_KEY } = await promptForClerkKeys();
   const ANTHROPIC_API_KEY = await promptForAnthropicApiKey();
   await promptForGitHubOAuth();
-  const NEXT_PUBLIC_BASE_URL = 'http://localhost:3000';
-  const BASE_URL = 'http://localhost:3000';
   const CLERK_SIGN_IN_FALLBACK_REDIRECT_URL = '/dashboard';
 
   await writeEnvFile({
-    NEXT_PUBLIC_BASE_URL,
-    BASE_URL,
     CLERK_SIGN_IN_FALLBACK_REDIRECT_URL,
     STRIPE_SECRET_KEY,
     STRIPE_WEBHOOK_SECRET,

--- a/lib/utils-server.test.ts
+++ b/lib/utils-server.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { baseUrl } from './utils-server';
+import { headers } from 'next/headers';
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(),
+}));
+
+describe('baseUrl', () => {
+  it('should return the correct base URL for development environment', () => {
+    vi.mocked(headers).mockReturnValue({
+      get: vi.fn().mockReturnValue('localhost:3000'),
+    } as any);
+
+    process.env.NODE_ENV = 'development';
+
+    expect(baseUrl()).toBe('http://localhost:3000');
+  });
+
+  it('should return the correct base URL for production environment', () => {
+    vi.mocked(headers).mockReturnValue({
+      get: vi.fn().mockReturnValue('example.com'),
+    } as any);
+
+    process.env.NODE_ENV = 'production';
+
+    expect(baseUrl()).toBe('https://example.com');
+  });
+});

--- a/lib/utils-server.ts
+++ b/lib/utils-server.ts
@@ -1,0 +1,8 @@
+import { headers } from "next/headers"
+
+export function baseUrl() {
+  const headersList = headers()
+  const host = headersList.get('host')
+  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https'
+  return `${protocol}://${host}`
+}


### PR DESCRIPTION
feat: simplify URL handling with Next.js headers
    
- Remove BASE_URL and NEXT_PUBLIC_BASE_URL environment variables
- Add baseUrl() utility using Next.js headers() to dynamically get host
- Update Stripe redirect URLs to use baseUrl()
- Remove URL configuration from setup script
    
This change eliminates environment variables in favor of dynamically
detecting the correct URL at request time. Works automatically across all
environments: local development (http), Vercel deployments (https), and
custom domains.