### PR TITLE
security: prevent db queries from being callable on the client.

### DIFF
--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -1,4 +1,4 @@
-"use server";
+import "server-only"
 
 import { eq } from "drizzle-orm";
 import { db } from "./drizzle";

--- a/lib/payments/stripe.ts
+++ b/lib/payments/stripe.ts
@@ -1,3 +1,5 @@
+import "server-only"
+
 import Stripe from "stripe";
 import { redirect } from "next/navigation";
 import { User } from "@/lib/db/schema";

--- a/lib/utils-server.test.ts
+++ b/lib/utils-server.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { baseUrl } from './utils-server';
 import { headers } from 'next/headers';
+
+vi.mock("server-only", () => ({}));
+import { baseUrl } from './utils-server';
 
 vi.mock('next/headers', () => ({
   headers: vi.fn(),
@@ -12,7 +14,7 @@ describe('baseUrl', () => {
       get: vi.fn().mockReturnValue('localhost:3000'),
     } as any);
 
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
 
     expect(baseUrl()).toBe('http://localhost:3000');
   });
@@ -22,7 +24,7 @@ describe('baseUrl', () => {
       get: vi.fn().mockReturnValue('example.com'),
     } as any);
 
-    process.env.NODE_ENV = 'production';
+    vi.stubEnv('NODE_ENV', 'production');
 
     expect(baseUrl()).toBe('https://example.com');
   });

--- a/lib/utils-server.ts
+++ b/lib/utils-server.ts
@@ -1,3 +1,4 @@
+import "server-only"
 import { headers } from "next/headers"
 
 export function baseUrl() {


### PR DESCRIPTION
This PR changes `queries.ts` from "use-server" to "server-only", ensuring that DB query functions are reserved for server-side use.

Exported functions in a `"use-server"` file are exposed to the frontend. This meant users could call functions like `getUserByClerkId()` or `updateUserSubscription()` with an arbitrary `clerkId`.

https://nextjs.org/blog/security-nextjs-server-components-actions#write

Impact is low, since `clerkId` is a random value.