### PR TITLE
Fix Cli command args and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,18 +132,7 @@ pnpm vitest
 
 ## Setup Guide for Running and Building Shortest Package Locally
    
-When running `pnpm install` in the root, the `shortest` package will built and added in the `node_modules` folder. However, in order to run the tests locally using `pnpm test` or `shortest cli`, you need to do the following: 
-
-### Prerequisites
-
-- Playwright 
-- Chromium
-
-### Install Playwright and build package
-
-```bash
-pnpm add playwright
-pnpm exec playwright install 
+When running `pnpm install` in the root, the `shortest` package will be built and added in the `node_modules` folder. However, in order to use the cli, you need to setup the cli locally as follows:
 
 # to install shortest package
 pnpm install

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "db:migrate": "npx tsx lib/db/migrate.ts",
     "db:studio": "drizzle-kit studio",
     "stripe:webhooks": "stripe listen --forward-to http://localhost:3000/api/stripe/webhook",
-    "test": "vitest"
+    "test": "shortest"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^0.0.50",

--- a/packages/shortest/src/cli/bin.ts
+++ b/packages/shortest/src/cli/bin.ts
@@ -4,7 +4,17 @@ import { TestRunner } from '../core/runner.js';
 
 async function main() {
   const runner = new TestRunner(process.cwd());
-  await runner.runAll();
+  
+  const testPattern = process.argv[2];
+  
+  if (testPattern) {
+    await runner.runFile(testPattern);
+  } else {
+    await runner.runAll();
+  }
 }
 
-main().catch(console.error); 
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+}); 


### PR DESCRIPTION
Quick fix for command line args when identifying test files.
Remove prerequisite instructions from README file as that step is now shipped with shortest package. 