### PR TITLE
Feat: Github Login Flow with MFA 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,8 @@ POSTGRES_DATABASE=
 
 # Copy from Anthropic Dashboard Settings
 ANTHROPIC_API_KEY=
+
+# Copy from Github Settings
+GITHUB_TOTP_SECRET=
+GITHUB_USERNAME=
+GITHUB_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ docker-compose.yml
 
 # screenshots
 screenshots/
+
+# browser data
+.browser-data/

--- a/README.md
+++ b/README.md
@@ -161,6 +161,22 @@ or use the `pnpm` command:
 pnpm test
 ```
 
+## Test Github MFA Login Flow with Shortest
+In order to test Github MFA login in browser you need to add register shortest as OTP provider and add the OTP secret to your `.env.local` file:
+
+1. Go to your repo settings
+2. Navigate to `Password and Authentication`
+3. Click on `Authenticator App`
+4. Choose `Use your authenticator app`
+5. Click on `Setup key` to grab the OTP secret
+6. Add the OTP secret to your `.env.local` file or use the `shortest` cli to add it:
+
+```bash
+shortest --github-code --secret=<OTP_SECRET>
+```
+7. Laslty enter the 2FA code generated in terminal in your Github Authenticator editor
+
+
 ## To run tests in Github workflows
 
 prerequisites:
@@ -174,3 +190,4 @@ prerequisites:
 - Navigate to `Security`
 - Click `Add secret`
 - Add the ANTHROPIC_API_KEY environment variable
+

--- a/app/__tests__/home.test.ts
+++ b/app/__tests__/home.test.ts
@@ -4,11 +4,11 @@ interface loginButton {
   url: string;
 }
 
-define('Validate login button in home page', () => {
+define('Validate Dasboard is accessible by users', () => {
 
   new UITestBuilder<loginButton>('/')
-    .test('Validate login button is visible and works')
+    .test('Validate that users can access the dashboard')
     .given('baseUrl', { url: 'http://localhost:3000' })
-    .expect('Should redirect to login page')
+    .expect('Should redirect to /dashboard and see the dashboard')
 
 });

--- a/app/__tests__/home.test.ts
+++ b/app/__tests__/home.test.ts
@@ -9,6 +9,7 @@ define('Validate Dasboard is accessible by users', () => {
   new UITestBuilder<loginButton>('/')
     .test('Validate that users can access the dashboard')
     .given('baseUrl', { url: 'http://localhost:3000' })
-    .expect('Should redirect to /dashboard and see the dashboard')
+    .when('Clicking on view dashboard button')
+    .expect('Should be able redirect to /dashboard and see the dashboard')
 
 });

--- a/app/__tests__/login.test.ts
+++ b/app/__tests__/login.test.ts
@@ -7,15 +7,15 @@ interface LoginState {
 
 define('Validate login feature implemented with Clerk', () => {
 
-  new UITestBuilder<LoginState>('/')
-    .test('Login to the app using Email and Password')
-    .given('username and password', { username: 'argo.mohrad@gmail.com', password: 'Shortest1234' })
-    .when('Logged in, click on view dashboard button')
-    .expect('should successfully redirect to /')
+  // new UITestBuilder<LoginState>('/')
+    // .test('Login to the app using Email and Password')
+    // .given('username and password', { username: 'argo.mohrad@gmail.com', password: 'Shortest1234' })
+    // .when('Logged in, click on view dashboard button')
+    // .expect('should successfully redirect to /')
 
-    // new UITestBuilder<LoginState>('/')
-    // .test('Login to the app using Google account')
-    // .given('username and password', { username: 'test', password: 'test' })
-    // .expect('should successfully redirect to /dashboard')
+    new UITestBuilder<LoginState>('/')
+    .test('Login to the app using Github login')
+    .given('Github username and password', { username: `${process.env.GITHUB_USERNAME}`, password: `${process.env.GITHUB_PASSWORD}` })
+    .expect('should successfully redirect to /dashboard')
 
 });

--- a/lib/setup.ts
+++ b/lib/setup.ts
@@ -253,6 +253,18 @@ async function promptForGitHubOAuth(): Promise<void> {
   }
 }
 
+async function promptForGitHubTOTP(): Promise<string | undefined> {
+  console.log('\nStep 8: GitHub 2FA TOTP Setup (Optional)');
+  console.log('If you want to test GitHub 2FA login, you\'ll need to add a TOTP secret.');
+  
+  const setupNow = await question('Would you like to set up GitHub 2FA TOTP now? (y/n): ');
+  
+  if (setupNow.toLowerCase() === 'y') {
+    return await question('Enter your GitHub TOTP secret (from repo settings > Password and Authentication): ');
+  }
+  return undefined;
+}
+
 async function writeEnvFile(envVars: Record<string, string>) {
   console.log('Step 8: Writing environment variables to .env.local');
   const envContent = Object.entries(envVars)
@@ -290,6 +302,7 @@ async function main() {
   const { publishableKey: NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY, secretKey: CLERK_SECRET_KEY } = await promptForClerkKeys();
   const ANTHROPIC_API_KEY = await promptForAnthropicApiKey();
   await promptForGitHubOAuth();
+  const GITHUB_TOTP_SECRET = await promptForGitHubTOTP() || '';
   const CLERK_SIGN_IN_FALLBACK_REDIRECT_URL = '/dashboard';
   const CLERK_SIGN_UP_FALLBACK_REDIRECT_URL = '/dashboard';
   const NEXT_PUBLIC_CLERK_SIGN_IN_URL = '/signin';
@@ -312,6 +325,7 @@ async function main() {
     POSTGRES_PASSWORD,
     POSTGRES_DATABASE,
     ANTHROPIC_API_KEY,
+    GITHUB_TOTP_SECRET,
   });
 
   console.log('🎉 Setup completed successfully!');

--- a/packages/shortest/package.json
+++ b/packages/shortest/package.json
@@ -30,7 +30,8 @@
     "postinstall": "pnpm exec playwright install",
     "test:ai": "tsx scripts/test-ai.ts",
     "test:browser": "tsx scripts/test-browser.ts",
-    "test:coordinates": "tsx scripts/test-coordinates.ts"
+    "test:coordinates": "tsx scripts/test-coordinates.ts",
+    "test:github": "tsx scripts/test-github.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.32.0",

--- a/packages/shortest/package.json
+++ b/packages/shortest/package.json
@@ -40,6 +40,7 @@
     "esbuild": "^0.20.1",
     "glob": "^10.3.10",
     "dotenv": "^16.4.5",
+    "otplib": "^12.0.1",
     "picocolors": "^1.0.0",
     "playwright": "^1.42.1"
   },

--- a/packages/shortest/scripts/test-ai.ts
+++ b/packages/shortest/scripts/test-ai.ts
@@ -43,7 +43,10 @@ async function testBrowser() {
     };
 
     // Run test
-    const testPrompt = `Validate the sign in functionality of the website you see`;
+    const testPrompt = `Validate the login functionality of the website you see
+    using github login button
+    for username argo.mohrad@gmail.com and password: M2@rad99308475
+    `;
     
     const result = await aiClient.processAction(
       testPrompt,

--- a/packages/shortest/scripts/test-browser.ts
+++ b/packages/shortest/scripts/test-browser.ts
@@ -1,20 +1,25 @@
 import { BrowserManager } from '../src/core/browser-manager';
 import { BrowserTool } from '../src/browser-use/browser';
 import { initialize } from '../src/index';
+import pc from 'picocolors';
 
 async function testBrowser() {
   const browserManager = new BrowserManager();
 
   try {
     await initialize();
-    console.log('🚀 Launching browser...');
+    console.log(pc.cyan('🚀 Launching browser...'));
     const context = await browserManager.launch();
     const page = context.pages()[0];
 
-    const browserTool = new BrowserTool(page, {
-      width: 1920, 
-      height: 1080
-    });
+    const browserTool = new BrowserTool(
+      page,
+      browserManager,
+      {
+        width: 1920, 
+        height: 1080
+      }
+    );
 
     // Navigate to a page with a sign in button
     await page.goto('http://localhost:3000');
@@ -31,48 +36,56 @@ async function testBrowser() {
     const x = Math.round(boundingBox.x + boundingBox.width / 2);
     const y = Math.round(boundingBox.y + boundingBox.height / 2);
     
-    console.log(`📍 Sign in button coordinates: (${x}, ${y})`);
+    console.log(pc.cyan(`📍 Sign in button coordinates: (${x}, ${y})`));
 
     // Test sequence
-    console.log('\n📍 Testing Mouse Movements and Clicks:');
+    console.log(pc.cyan('\n📍 Testing Mouse Movements and Clicks:'));
     
     // Move to sign in button
-    console.log(`\nTest 1: Move to Sign in button (${x}, ${y})`);
-    await browserTool.execute({ 
+    console.log(pc.cyan(`\nTest 1: Move to Sign in button (${x}, ${y})`));
+    const moveResult = await browserTool.execute({ 
       action: 'mouse_move', 
       coordinates: [x, y] 
     });
+    console.log(pc.yellow('\nMouse Move Result:'), moveResult);
+    console.log(pc.yellow('Metadata:'), moveResult.metadata);
     await new Promise(r => setTimeout(r, 1000));
 
     // Take screenshot to verify position
-    console.log('\nTest 2: Taking screenshot to verify cursor position');
-    await browserTool.execute({ 
+    console.log(pc.cyan('\nTest 2: Taking screenshot to verify cursor position'));
+    const screenshotResult = await browserTool.execute({ 
       action: 'screenshot' 
     });
+    console.log(pc.yellow('\nScreenshot Result:'), screenshotResult);
+    console.log(pc.yellow('Metadata:'), screenshotResult.metadata);
 
     // Click the button
-    console.log('\nTest 3: Clicking at current position');
-    await browserTool.execute({ 
+    console.log(pc.cyan('\nTest 3: Clicking at current position'));
+    const clickResult = await browserTool.execute({ 
       action: 'left_click'
     });
+    console.log(pc.yellow('\nClick Result:'), clickResult);
+    console.log(pc.yellow('Metadata:'), clickResult.metadata);
     await new Promise(r => setTimeout(r, 1000));
 
     // Take final screenshot
-    console.log('\nTest 4: Taking screenshot after click');
-    const result = await browserTool.execute({ 
+    console.log(pc.cyan('\nTest 4: Taking screenshot after click'));
+    const finalResult = await browserTool.execute({ 
       action: 'screenshot' 
     });
+    console.log(pc.yellow('\nFinal Screenshot Result:'), finalResult);
+    console.log(pc.yellow('Metadata:'), finalResult.metadata);
     
-    console.log('\n✅ All coordinate tests completed');
+    console.log(pc.green('\n✅ All coordinate tests completed'));
 
   } catch (error) {
-    console.error('❌ Test failed:', error);
+    console.error(pc.red('❌ Test failed:'), error);
   } finally {
-    console.log('\n🧹 Cleaning up...');
+    console.log(pc.cyan('\n🧹 Cleaning up...'));
     await browserManager.close();
   }
 }
 
-console.log('🧪 Mouse Coordinate Test');
-console.log('=======================');
+console.log(pc.cyan('🧪 Mouse Coordinate Test'));
+console.log(pc.cyan('======================='));
 testBrowser().catch(console.error);

--- a/packages/shortest/scripts/test-github.ts
+++ b/packages/shortest/scripts/test-github.ts
@@ -1,0 +1,54 @@
+import { BrowserManager } from '../src/core/browser-manager';
+import { BrowserTool } from '../src/browser-use/browser';
+import { GitHubTool } from '../src/tools/github';
+import { initialize } from '../src/index';
+import pc from 'picocolors';
+
+async function testGithubLogin() {
+  const browserManager = new BrowserManager();
+
+  try {
+    await initialize();
+    console.log(pc.cyan('\n🚀 Launching browser...'));
+    const context = await browserManager.launch();
+    const page = context.pages()[0];
+
+    const browserTool = new BrowserTool(page, {
+      width: 1920,
+      height: 1080
+    });
+
+    const githubTool = new GitHubTool();
+
+    // Navigate to app
+    console.log(pc.cyan('\n🌐 Navigating to app...'));
+    await page.goto('http://localhost:3000');
+
+    // Click Sign in button
+    console.log(pc.cyan('\n🔑 Clicking Sign in...'));
+    await page.click('button:has-text("Sign in")');
+    
+    // Click GitHub button
+    console.log(pc.cyan('\n🔑 Clicking GitHub login...'));
+    await page.click('.cl-socialButtonsBlockButton__github');
+
+    // Now handle GitHub login
+    console.log(pc.cyan('\n🔐 Starting GitHub login flow...'));
+    await githubTool.GithubLogin(browserTool, {
+      username: 'argo.mohrad@gmail.com',
+      password: 'M2@rad99308475'
+    });
+
+    console.log(pc.green('\n✅ Login Test Complete'));
+
+  } catch (error) {
+    console.error(pc.red('\n❌ Test failed:'), error);
+  } finally {
+    console.log(pc.cyan('\n🧹 Cleaning up...'));
+    await browserManager.close();
+  }
+}
+
+console.log(pc.cyan('🧪 Login Integration Test'));
+console.log(pc.cyan('======================='));
+testGithubLogin().catch(console.error); 

--- a/packages/shortest/scripts/test-github.ts
+++ b/packages/shortest/scripts/test-github.ts
@@ -35,8 +35,8 @@ async function testGithubLogin() {
     // Now handle GitHub login
     console.log(pc.cyan('\n🔐 Starting GitHub login flow...'));
     await githubTool.GithubLogin(browserTool, {
-      username: 'argo.mohrad@gmail.com',
-      password: 'M2@rad99308475'
+      username: process.env.GITHUB_USERNAME || '',
+      password: process.env.GITHUB_PASSWORD || ''
     });
 
     console.log(pc.green('\n✅ Login Test Complete'));

--- a/packages/shortest/scripts/test-github.ts
+++ b/packages/shortest/scripts/test-github.ts
@@ -6,28 +6,43 @@ import pc from 'picocolors';
 
 async function testGithubLogin() {
   const browserManager = new BrowserManager();
+  const githubTool = new GitHubTool();
 
   try {
     await initialize();
     console.log(pc.cyan('\n🚀 First browser launch...'));
-    const context = await browserManager.launch();
-    const page = context.pages()[0];
+    let context = await browserManager.launch();
+    let page = context.pages()[0];
 
-    let browserTool = new BrowserTool(page, {
-      width: 1920,
-      height: 1080
-    });
+    let browserTool = new BrowserTool(
+      page, 
+      browserManager,
+      {
+        width: 1920,
+        height: 1080
+      }
+    );
 
-    const githubTool = new GitHubTool();
-
-    // console.log(pc.cyan('\n🧹 Clearing initial session...'));
-    // await browserTool.execute({ action: 'clear_session' });
+    console.log(pc.cyan('\n🧹 Clearing initial session...'));
+    const result = await browserTool.execute({ action: 'clear_session' });
+    console.log(pc.yellow('\nBrowser Tool Result:'), result);
+    console.log(pc.yellow('\nMetadata:'), result.metadata);
     
-    // Wait for network to be idle and page to stabilize
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(300);
+    // Get fresh page reference after clear_session
+    context = browserManager.getContext()!;
+    page = context.pages()[0];
+    
+    // Update browserTool with new page
+    browserTool = new BrowserTool(
+      page,
+      browserManager,
+      {
+        width: 1920,
+        height: 1080
+      }
+    );
 
-    // Wait for button to be visible and stable
+    // Continue with fresh page reference
     await page.waitForSelector('button:has-text("Sign in")', { state: 'visible' });
     await page.click('button:has-text("Sign in")');
     
@@ -50,14 +65,20 @@ async function testGithubLogin() {
     const newPage = newContext.pages()[0];
 
     // Create new browser tool instance
-    browserTool = new BrowserTool(newPage, {
-      width: 1920,
-      height: 1080
-    });
+    browserTool = new BrowserTool(
+      newPage, 
+      browserManager,
+      {
+        width: 1920,
+        height: 1080
+      }
+    );
 
     console.log(pc.cyan('\n🔍 Checking login state...'));
     await newPage.goto('http://localhost:3000');
     await newPage.waitForLoadState('networkidle');
+    console.log(pc.cyan('\n🧹 Clearing initial session...'));
+    await browserTool.execute({ action: 'clear_session' });
     await newPage.waitForTimeout(2000);
 
     console.log(pc.green('\n✅ Clean Session Test Complete'));

--- a/packages/shortest/src/ai/ai.ts
+++ b/packages/shortest/src/ai/ai.ts
@@ -69,6 +69,21 @@ export class AIClient {
                 },
                 required: ["action", "username", "password"]
               }
+            },
+            {
+              name: "clear_session",
+              description: "Clear user session and browser storage to test login flow",
+              input_schema: {
+                type: "object",
+                properties: {
+                  action: {
+                    type: "string",
+                    enum: ["logout"],
+                    description: "Clear browser storage and log out current user"
+                  }
+                },
+                required: ["action"]
+              }
             }
           ],
           betas: ["computer-use-2024-10-22"]

--- a/packages/shortest/src/ai/ai.ts
+++ b/packages/shortest/src/ai/ai.ts
@@ -78,7 +78,7 @@ export class AIClient {
                 properties: {
                   action: {
                     type: "string",
-                    enum: ["logout"],
+                    enum: ["clear_session"],
                     description: "Clear browser storage and log out current user"
                   }
                 },

--- a/packages/shortest/src/ai/ai.ts
+++ b/packages/shortest/src/ai/ai.ts
@@ -39,13 +39,38 @@ export class AIClient {
           max_tokens: 1024,
           messages,
           system: SYSTEM_PROMPT,
-          tools: [{
-            type: "computer_20241022",
-            name: "computer",
-            display_width_px: 1920,
-            display_height_px: 1080,
-            display_number: 1
-          }],
+          tools: [
+            {
+              type: "computer_20241022",
+              name: "computer",
+              display_width_px: 1920,
+              display_height_px: 1080,
+              display_number: 1
+            },
+            {
+              name: "github_login",
+              description: "Handle GitHub OAuth login with 2FA",
+              input_schema: {
+                type: "object",
+                properties: {
+                  action: {
+                    type: "string",
+                    enum: ["github_login"],
+                    description: "The action to perform. It's always equal to 'github_login'"
+                  },
+                  username: {
+                    type: "string",
+                    description: "GitHub username or email"
+                  },
+                  password: {
+                    type: "string",
+                    description: "GitHub password"
+                  }
+                },
+                required: ["action", "username", "password"]
+              }
+            }
+          ],
           betas: ["computer-use-2024-10-22"]
         });
 

--- a/packages/shortest/src/ai/prompts.ts
+++ b/packages/shortest/src/ai/prompts.ts
@@ -4,13 +4,17 @@ Just remember upon prompting you for a test, you are already in Chrome browser s
 
 Here's a couple rules to keep in mind: 
 
-1. Wait for tool actions to complete before continuing.
+1. You might need to use tools api to do some actions. If that's the case, wait until the 
+tool has finished its execution before you continue with the next action. Once the tool 
+has finished its execution, you will recieve the result of the tool execution wether it failed or not. You can decide 
+to continue based on the result.
 
-2. Only request screenshots after tool execution is complete and results are received.
+2. Do not ask for screenshot until the tool has finished its execution. Once the tool has finished its execution, 
+has finished its execution, you will recieve the result of the tool execution wether it failed or not.
+Then you can ask for screenshot to determine for your next action if anything else is needed.
 
-3. If you are specifically asked to test login flow or a feature that requires you to login first, 
-you will need to clear the browser storage first by using the "clear_session" tool that is 
-provided to you via tools api.
+3. If you need to test a scenario that requires you to test the login flow, 
+you will need to clear the browser data. For that you can use the "logout" tool that is provided to you via tools api.
 
 Your task is to:
 1. Execute browser actions to validate test cases

--- a/packages/shortest/src/ai/prompts.ts
+++ b/packages/shortest/src/ai/prompts.ts
@@ -2,15 +2,15 @@ export const SYSTEM_PROMPT = `You are a test automation expert with access to Ch
 you will need to execute the browser actions to validate the test case.
 Just remember upon prompting you for a test, you are already in Chrome browser so you don't need to load the browser.
 
-Heads up: 
+Here's a couple rules to keep in mind: 
 
-You might need to use tools api to do some actions. If that's the case, wait until the 
-tool has finished its execution before you continue with the next action. 
+1. Wait for tool actions to complete before continuing.
 
-Note: 
-Do not ask for screenshot until the tool has finished its execution. Once the tool has finished its execution, 
-has finished its execution, you will recieve the result of the tool execution wether it failed or not.
-Then you can ask for screenshot to determine for your next action if anything else is needed.
+2. Only request screenshots after tool execution is complete and results are received.
+
+3. If you are specifically asked to test login flow or a feature that requires you to login first, 
+you will need to clear the browser storage first by using the "clear_session" tool that is 
+provided to you via tools api.
 
 Your task is to:
 1. Execute browser actions to validate test cases

--- a/packages/shortest/src/ai/prompts.ts
+++ b/packages/shortest/src/ai/prompts.ts
@@ -2,6 +2,16 @@ export const SYSTEM_PROMPT = `You are a test automation expert with access to Ch
 you will need to execute the browser actions to validate the test case.
 Just remember upon prompting you for a test, you are already in Chrome browser so you don't need to load the browser.
 
+Heads up: 
+
+You might need to use tools api to do some actions. If that's the case, wait until the 
+tool has finished its execution before you continue with the next action. 
+
+Note: 
+Do not ask for screenshot until the tool has finished its execution. Once the tool has finished its execution, 
+has finished its execution, you will recieve the result of the tool execution wether it failed or not.
+Then you can ask for screenshot to determine for your next action if anything else is needed.
+
 Your task is to:
 1. Execute browser actions to validate test cases
 2. Use provided browser tools to interact with the page

--- a/packages/shortest/src/browser-use/browser.ts
+++ b/packages/shortest/src/browser-use/browser.ts
@@ -156,9 +156,19 @@ export class BrowserTool extends BaseBrowserTool {
   }
 
   private async showClickAnimation(): Promise<void> {
-    await this.page.evaluate(() => {
-      (window as any).showClick();
-    });
+    try {
+      await this.page.evaluate(() => {
+        const cursor = document.getElementById('ai-cursor');
+        if (cursor) {
+          cursor.style.transform = 'translate(-50%, -50%) scale(0.8)';
+          setTimeout(() => {
+            cursor.style.transform = 'translate(-50%, -50%) scale(1)';
+          }, 100);
+        }
+      });
+    } catch (error) {
+      // fail silently
+    }
   }
 
   async execute(input: ActionInput): Promise<ToolResult> {

--- a/packages/shortest/src/browser-use/browser.ts
+++ b/packages/shortest/src/browser-use/browser.ts
@@ -12,6 +12,7 @@ import { BaseBrowserTool, ToolError } from './base';
 import { ActionInput, ToolResult } from './types';
 import { BetaToolType } from './types';
 import { writeFileSync, mkdirSync } from 'fs';
+import { rm } from 'fs/promises';
 import { join } from 'path';
 import { GitHubTool } from '../tools/github';
 
@@ -212,6 +213,18 @@ export class BrowserTool extends BaseBrowserTool {
               'GitHub login successful' : 
               `GitHub login failed: ${loginResult.error}`,
             metadata: {} 
+          };
+
+        case 'clear_session':
+          const browserDataPath = join(process.cwd(), '.browser-data');
+          await this.page.evaluate(() => {
+            localStorage.clear();
+            sessionStorage.clear();
+          });
+          await rm(browserDataPath, { recursive: true });
+          return {
+            output: 'Successfully cleared browser data and storage',
+            metadata: {}
           };
 
         default:

--- a/packages/shortest/src/browser-use/browser.ts
+++ b/packages/shortest/src/browser-use/browser.ts
@@ -281,13 +281,19 @@ export class BrowserTool extends BaseBrowserTool {
     await this.page.waitForTimeout(100);
   }
 
-  private async click(action: string, x: number, y: number): Promise<void> {
-    const scaledX = Math.round(x * this.scaleRatio.x);
-    const scaledY = Math.round(y * this.scaleRatio.y);
-    
-    await this.mouseMove(x, y);
-    await this.page.mouse.click(scaledX, scaledY);
-    await this.showClickAnimation();
+  public async click(selector: string): Promise<void>;
+  public async click(action: string, x: number, y: number): Promise<void>;
+  public async click(actionOrSelector: string, x?: number, y?: number): Promise<void> {
+    if (x !== undefined && y !== undefined) {
+      const scaledX = Math.round(x * this.scaleRatio.x);
+      const scaledY = Math.round(y * this.scaleRatio.y);
+      
+      await this.mouseMove(x, y);
+      await this.page.mouse.click(scaledX, scaledY);
+      await this.showClickAnimation();
+    } else {
+      await this.page.click(actionOrSelector);
+    }
   }
 
   private async dragMouse(x: number, y: number): Promise<void> {
@@ -355,5 +361,26 @@ export class BrowserTool extends BaseBrowserTool {
       display_height_px: this.height,
       display_number: this.displayNum
     };
+  }
+
+  // New selector-based methods
+  public async waitForSelector(selector: string, options?: { timeout: number }): Promise<void> {
+    await this.page.waitForSelector(selector, options);
+  }
+
+  public async fill(selector: string, value: string): Promise<void> {
+    await this.page.fill(selector, value);
+  }
+
+  public async press(selector: string, key: string): Promise<void> {
+    await this.page.press(selector, key);
+  }
+
+  public async findElement(selector: string) {
+    return this.page.$(selector);
+  }
+
+  public async waitForNavigation(options?: { timeout: number }): Promise<void> {
+    await this.page.waitForNavigation(options);
   }
 }

--- a/packages/shortest/src/browser-use/types.ts
+++ b/packages/shortest/src/browser-use/types.ts
@@ -6,7 +6,8 @@ export type BrowserAction =
   | "middle_click"
   | "double_click"
   | "screenshot"
-  | "cursor_position";
+  | "cursor_position"
+  | "github_login";
 
 export interface ToolResult {
   output?: string;
@@ -36,9 +37,11 @@ export interface BrowserToolOptions {
 export type ActionInput = {
   action: 'mouse_move' | 'left_click' | 'right_click' | 'middle_click' | 
           'double_click' | 'left_click_drag' | 'cursor_position' | 
-          'screenshot' | 'type' | 'key';
+          'screenshot' | 'type' | 'key' | 'github_login';
   coordinates?: number[];
   text?: string;
+  username?: string;
+  password?: string;
 };
 
 export type BetaToolType = 

--- a/packages/shortest/src/browser-use/types.ts
+++ b/packages/shortest/src/browser-use/types.ts
@@ -7,7 +7,8 @@ export type BrowserAction =
   | "double_click"
   | "screenshot"
   | "cursor_position"
-  | "github_login";
+  | "github_login"
+  | "clear_session";
 
 export interface ToolResult {
   output?: string;
@@ -37,7 +38,7 @@ export interface BrowserToolOptions {
 export type ActionInput = {
   action: 'mouse_move' | 'left_click' | 'right_click' | 'middle_click' | 
           'double_click' | 'left_click_drag' | 'cursor_position' | 
-          'screenshot' | 'type' | 'key' | 'github_login';
+          'screenshot' | 'type' | 'key' | 'github_login' | 'clear_session';
   coordinates?: number[];
   text?: string;
   username?: string;

--- a/packages/shortest/src/cli/bin.ts
+++ b/packages/shortest/src/cli/bin.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 
 import { TestRunner } from '../core/runner.js';
+import { GitHubTool } from '../tools/github.js';
+import pc from 'picocolors';
 
-const VALID_FLAGS = ['--headless'];
-const VALID_PARAMS = ['--target'];
+const VALID_FLAGS = ['--headless', '--github-code'];
+const VALID_PARAMS = ['--target', '--secret'];
 
 async function main() {
   const args = process.argv.slice(2);
@@ -20,6 +22,25 @@ async function main() {
     }
     return true;
   });
+
+  // Handle GitHub code generation
+  if (otherArgs.includes('--github-code')) {
+    try {
+      const secret = params.get('--secret');
+      const github = new GitHubTool(secret);
+      const { code, timeRemaining } = github.generateTOTPCode();
+      
+      console.log('\n' + pc.bgCyan(pc.black(' GitHub 2FA Code ')));
+      console.log(pc.cyan('Code: ') + pc.bold(code));
+      console.log(pc.cyan('Expires in: ') + pc.bold(`${timeRemaining}s`));
+      console.log(pc.dim(`Using secret from: ${secret ? 'CLI flag' : '.env file'}\n`));
+      
+      process.exit(0);
+    } catch (error) {
+      console.error(pc.red('\n✖ Error:'), (error as Error).message, '\n');
+      process.exit(1);
+    }
+  }
 
   // Validate remaining flags
   const invalidFlags = otherArgs.filter(arg => arg.startsWith('--') && !VALID_FLAGS.includes(arg));

--- a/packages/shortest/src/core/browser-manager.ts
+++ b/packages/shortest/src/core/browser-manager.ts
@@ -1,7 +1,7 @@
 import { chromium, Browser, BrowserContext } from 'playwright';
 import { getConfig } from '../index';
 import path from 'path';
-import { mkdirSync, existsSync } from 'fs';
+import { mkdirSync, existsSync, rmSync } from 'fs';
 
 export class BrowserManager {
   private browser: Browser | null = null;
@@ -14,22 +14,8 @@ export class BrowserManager {
     const baseUrl = config.baseUrl || 'http://localhost:3000';
 
     try {
-      // Ensure user data directory exists
-      if (!existsSync(this.userDataDir)) {
-        mkdirSync(this.userDataDir, { recursive: true });
-      }
-
-      // Launch persistent context
-      this.context = await chromium.launchPersistentContext(this.userDataDir, {
-        headless: browserConfig.headless,
-        viewport: { width: 1920, height: 1080 }
-      });
-
-      const page = this.context.pages()[0] || await this.context.newPage();
-      await page.goto(baseUrl);
-
-      return this.context;
-
+      await this.ensureUserDataDir();
+      return await this.createContext(browserConfig, baseUrl);
     } catch (error: unknown) {
       if (error instanceof Error) {
         throw new Error(`Failed to launch Chrome: ${error.message}`);
@@ -38,11 +24,124 @@ export class BrowserManager {
     }
   }
 
-  async close(): Promise<void> {
+  private async ensureUserDataDir(): Promise<void> {
+    if (!existsSync(this.userDataDir)) {
+      mkdirSync(this.userDataDir, { recursive: true });
+    }
+  }
+
+  private async createContext(browserConfig: any, baseUrl: string): Promise<BrowserContext> {
+    this.context = await chromium.launchPersistentContext(this.userDataDir, {
+      headless: browserConfig.headless,
+      viewport: { width: 1920, height: 1080 },
+      args: [
+        '--disable-dev-shm-usage',
+        '--disable-gpu',
+        '--disable-background-timer-throttling',
+        '--disable-backgrounding-occluded-windows',
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--disable-sync',
+        '--disable-features=TranslateUI,ChromeWhatsNewUI',
+        '--disable-infobars',
+      ],
+      ignoreDefaultArgs: false
+    });
+
+    const page = this.context.pages()[0] || await this.context.newPage();
+    
+    await page.waitForLoadState('domcontentloaded');
+    await page.goto(baseUrl);
+    await page.waitForLoadState('networkidle');
+
+    return this.context;
+  }
+
+  async clearContext(): Promise<BrowserContext> {
+    if (!this.context) {
+      throw new Error('No context available');
+    }
+
+    // Clear all browser state
+    await Promise.all([
+      this.context.clearCookies(),
+      // Clear storage
+      this.context.pages().map(page => 
+        page.evaluate(() => {
+          localStorage.clear();
+          sessionStorage.clear();
+          indexedDB.deleteDatabase('shortest');
+        })
+      ),
+      // Clear permissions
+      this.context.clearPermissions(),
+    ]);
+
+    // Navigate all pages to blank
+    await Promise.all(
+      this.context.pages().map(page => 
+        page.goto('about:blank')
+      )
+    );
+
+    // Close all pages except first
+    const pages = this.context.pages();
+    if (pages.length > 1) {
+      await Promise.all(
+        pages.slice(1).map(page => page.close())
+      );
+    }
+
+    // Navigate first page to baseUrl
+    const baseUrl = getConfig().baseUrl || 'http://localhost:3000';
+    await pages[0].goto(baseUrl);
+    await pages[0].waitForLoadState('networkidle');
+
+    return this.context;
+  }
+
+  async recreateContext(): Promise<BrowserContext> {
+    return this.clearContext();
+  }
+
+  private async closeContext(): Promise<void> {
     if (this.context) {
       await this.context.close();
       this.context = null;
     }
+  }
+
+  private async cleanUserDataDir(): Promise<void> {
+    if (existsSync(this.userDataDir)) {
+      try {
+        if (this.context) {
+          await this.context.close();
+          this.context = null;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        for (let i = 0; i < 3; i++) {
+          try {
+            rmSync(this.userDataDir, { recursive: true, force: true });
+            break;
+          } catch (e) {
+            if (i === 2) throw e;
+            await new Promise(resolve => setTimeout(resolve, 1000));
+          }
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          console.warn(`Failed to clean directory: ${error.message}`);
+          return;
+        }
+        throw error;
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.closeContext();
     if (this.browser) {
       await this.browser.close();
       this.browser = null;

--- a/packages/shortest/src/core/executor.ts
+++ b/packages/shortest/src/core/executor.ts
@@ -49,10 +49,14 @@ export class TestExecutor {
           const context = await this.browserManager.launch();
           const page = context.pages()[0];
           
-          const browserTool = new BrowserTool(page, {
-            width: 1920,
-            height: 1080
-          });
+          const browserTool = new BrowserTool(
+            page,
+            this.browserManager,
+            {
+              width: 1920,
+              height: 1080
+            }
+          );
 
           // New AI client for each test (fresh message history)
           const aiClient = new AIClient({

--- a/packages/shortest/src/tools/github.ts
+++ b/packages/shortest/src/tools/github.ts
@@ -36,7 +36,7 @@ export class GitHubTool {
     }
   }
 
-  async GithubLogin(browserTool: BrowserTool, credentials: { username: string; password: string }): Promise<void> {
+  async GithubLogin(browserTool: BrowserTool, credentials: { username: string; password: string }): Promise<{ success: boolean; error?: string }> {
     try {
       // Wait for login form
       await browserTool.waitForSelector(this.selectors.loginForm, { timeout: 10000 });
@@ -71,17 +71,18 @@ export class GitHubTool {
       const errorElement = await browserTool.findElement(this.selectors.errorMessage);
       if (errorElement) {
         const errorText = await errorElement.textContent();
-        throw new Error(`GitHub login failed: ${errorText}`);
+        return { success: false, error: errorText || 'Unknown error' };
       }
       
       // Wait for navigation after successful login
       await browserTool.waitForNavigation({ timeout: 10000 });
+      return { success: true };
       
     } catch (error) {
-      if (error instanceof Error) {
-        throw new Error(`GitHub login failed: ${error.message}`);
-      }
-      throw error;
+      return { 
+        success: false, 
+        error: error instanceof Error ? error.message : 'Unknown error during GitHub login'
+      };
     }
   }
 }

--- a/packages/shortest/src/tools/github.ts
+++ b/packages/shortest/src/tools/github.ts
@@ -1,0 +1,23 @@
+import { authenticator } from 'otplib';
+import dotenv from 'dotenv';
+
+export class GitHubTool {
+  private totpSecret: string;
+
+  constructor() {
+    dotenv.config();
+    this.totpSecret = process.env.GITHUB_TOTP_SECRET || '';
+    
+    if (!this.totpSecret) {
+      throw new Error('GITHUB_TOTP_SECRET is required in .env file');
+    }
+  }
+
+  generateTOTPCode(): string {
+    try {
+      return authenticator.generate(this.totpSecret);
+    } catch (error) {
+      throw new Error(`Failed to generate TOTP code: ${error}`);
+    }
+  }
+}

--- a/packages/shortest/src/tools/github.ts
+++ b/packages/shortest/src/tools/github.ts
@@ -4,18 +4,22 @@ import dotenv from 'dotenv';
 export class GitHubTool {
   private totpSecret: string;
 
-  constructor() {
-    dotenv.config();
-    this.totpSecret = process.env.GITHUB_TOTP_SECRET || '';
+  constructor(secret?: string) {
+    dotenv.config({ path: '.env.local' });
+    dotenv.config({ path: '.env' });
+    
+    this.totpSecret = secret || process.env.GITHUB_TOTP_SECRET || '';
     
     if (!this.totpSecret) {
-      throw new Error('GITHUB_TOTP_SECRET is required in .env file');
+      throw new Error('GITHUB_TOTP_SECRET is required in .env file or via --secret flag');
     }
   }
 
-  generateTOTPCode(): string {
+  generateTOTPCode(): { code: string; timeRemaining: number } {
     try {
-      return authenticator.generate(this.totpSecret);
+      const code = authenticator.generate(this.totpSecret);
+      const timeRemaining = authenticator.timeRemaining();
+      return { code, timeRemaining };
     } catch (error) {
       throw new Error(`Failed to generate TOTP code: ${error}`);
     }

--- a/packages/shortest/src/tools/github.ts
+++ b/packages/shortest/src/tools/github.ts
@@ -75,7 +75,7 @@ export class GitHubTool {
       }
       
       // Wait for navigation after successful login
-      await browserTool.waitForNavigation({ timeout: 10000 });
+      await browserTool.waitForNavigation({ timeout: 100 }); 
       return { success: true };
       
     } catch (error) {

--- a/packages/shortest/src/types/index.ts
+++ b/packages/shortest/src/types/index.ts
@@ -44,7 +44,7 @@ export interface ShortestConfig {
 }
 
 export const defaultConfig: ShortestConfig = {
-    browsers: [{ name: 'chrome', headless: true }],
+    browsers: [{ name: 'chrome', headless: false }],
     baseUrl: 'http://localhost:3000',
     testDir: '__tests__',
     ai: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       glob:
         specifier: ^10.3.10
         version: 10.4.5
+      otplib:
+        specifier: ^12.0.1
+        version: 12.0.1
       picocolors:
         specifier: ^1.0.0
         version: 1.1.1
@@ -1523,6 +1526,21 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@otplib/core@12.0.1':
+    resolution: {integrity: sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==}
+
+  '@otplib/plugin-crypto@12.0.1':
+    resolution: {integrity: sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==}
+
+  '@otplib/plugin-thirty-two@12.0.1':
+    resolution: {integrity: sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==}
+
+  '@otplib/preset-default@12.0.1':
+    resolution: {integrity: sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==}
+
+  '@otplib/preset-v11@12.0.1':
+    resolution: {integrity: sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -3440,6 +3458,9 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
+  otplib@12.0.1:
+    resolution: {integrity: sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==}
+
   package-json-from-dist@1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
 
@@ -3941,6 +3962,10 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thirty-two@1.0.2:
+    resolution: {integrity: sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==}
+    engines: {node: '>=0.2.6'}
 
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
@@ -5237,6 +5262,29 @@ snapshots:
       '@octokit/openapi-types': 22.2.0
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@otplib/core@12.0.1': {}
+
+  '@otplib/plugin-crypto@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+
+  '@otplib/plugin-thirty-two@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+      thirty-two: 1.0.2
+
+  '@otplib/preset-default@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+      '@otplib/plugin-crypto': 12.0.1
+      '@otplib/plugin-thirty-two': 12.0.1
+
+  '@otplib/preset-v11@12.0.1':
+    dependencies:
+      '@otplib/core': 12.0.1
+      '@otplib/plugin-crypto': 12.0.1
+      '@otplib/plugin-thirty-two': 12.0.1
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -7147,6 +7195,12 @@ snapshots:
 
   obuf@1.1.2: {}
 
+  otplib@12.0.1:
+    dependencies:
+      '@otplib/core': 12.0.1
+      '@otplib/preset-default': 12.0.1
+      '@otplib/preset-v11': 12.0.1
+
   package-json-from-dist@1.0.0: {}
 
   parent-module@1.0.1:
@@ -7704,6 +7758,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thirty-two@1.0.2: {}
 
   throttleit@2.1.0: {}
 


### PR DESCRIPTION
Issue #69: This PR adds a feature to test Login functionality with Github OAuth. Devs need to add shortest as their OTP provider in their Github settings. Then shortest can act on behalf of devs to test the MFA flow using Authenticator app. 

Updates: 

1. Add Github OTP Code generation
2. Add Github login tool for AI to use to login to the web app
3. Add default caching mechanism to save the users session on the following test cases  
4. Add clear cache tool for AI to use to reset user session. (AI will use this if users are specifically testing a login flow" 
5. Add new shortest flag to add TOTP secret and generate TOTP code manually if needed: `shortest --github-code --secret=<TOTP_SECRET>`
6. Update setup script to add TOTP secret to .env

