### PR TITLE
Fix BrowserTool instantiation in test script

### DIFF
--- a/packages/shortest/scripts/test-loop.ts
+++ b/packages/shortest/scripts/test-loop.ts
@@ -24,7 +24,7 @@ async function testBrowser() {
     const context = await browserManager.launch();
     const page = context.pages()[0];
     
-    const browserTool = new BrowserTool(page, {
+    const browserTool = new BrowserTool(page, browserManager, {
       width: 1920, 
       height: 940
     });


### PR DESCRIPTION
Small error in test-loop.ts caused the build to fail in Vercel. This should fix that. 