### PR TITLE
Feature: Github workflow for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,36 @@
 name: Publish Package
 
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/shortest/**'
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/shortest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
-      - run: pnpm install
-      - run: pnpm test
-      - run: pnpm build
-      - run: pnpm publish --access public
+          cache: 'pnpm'
+      
+      - name: Install dependencies
+        run: pnpm install
+      
+      - name: Build
+        run: pnpm build
+      
+      - name: Publish to NPM
+        run: pnpm publish --access public --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}} 
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR adds a new workflow for publishing new versions of shortest to npm registry. 

### Prerequisite: 
1. Create NPM token
2. Add to GitHub Secrets: 
Go to repo Settings > Secrets and variables > Actions 
Add new secret named NPM_TOKEN with the token value

### Note: This branch is based off PR #89. Please resolve that one first. 
