### PR TITLE
fix pnpm version mismatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9.7.1
       - uses: actions/setup-node@v4
         with:
           node-version: '18'


### PR DESCRIPTION
Publish workflow failed because of pnpm version mismatch