### PR TITLE
add a basic implementation of a recording based tool and client

### DIFF
--- a/app/__tests__/duckduckgo.test.ts
+++ b/app/__tests__/duckduckgo.test.ts
@@ -1,0 +1,13 @@
+import { shortest } from "@antiwork/shortest";
+import { clerk, clerkSetup } from "@clerk/testing/playwright";
+
+let frontendUrl = "https://duckduckgo.com";
+
+shortest.beforeAll(async ({ page }) => {
+  await clerkSetup({
+    frontendApiUrl: frontendUrl,
+  });
+  await page.goto(frontendUrl);
+});
+
+shortest('Find out the NVIDIA stock price');

--- a/app/__tests__/google.test.ts
+++ b/app/__tests__/google.test.ts
@@ -1,0 +1,13 @@
+import { shortest } from "@antiwork/shortest";
+import { clerk, clerkSetup } from "@clerk/testing/playwright";
+
+let frontendUrl = "https://google.com";
+
+shortest.beforeAll(async ({ page }) => {
+  await clerkSetup({
+    frontendApiUrl: frontendUrl,
+  });
+  await page.goto(frontendUrl);
+});
+
+shortest('Find the wikipedia page of Lionel Messi');

--- a/packages/shortest/package.json
+++ b/packages/shortest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiwork/shortest",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AI-powered natural language end-to-end testing framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shortest/src/ai/client.ts
+++ b/packages/shortest/src/ai/client.ts
@@ -10,8 +10,9 @@ export class AIClient {
   private model: string;
   private maxMessages: number;
   private debugMode: boolean;
+  public basePrompt: string;
 
-  constructor(config: AIConfig, debugMode: boolean = false) {
+  constructor(config: AIConfig, debugMode: boolean = true) {
     if (!config.apiKey) {
       throw new Error('Anthropic API key is required. Set it in shortest.config.ts or ANTHROPIC_API_KEY env var');
     }
@@ -21,7 +22,8 @@ export class AIClient {
     });
     this.model = 'claude-3-5-sonnet-20241022';
     this.maxMessages = 10;
-    this.debugMode = debugMode;
+    this.debugMode = true;
+    this.basePrompt = SYSTEM_PROMPT;
   }
 
   async processAction(
@@ -72,7 +74,7 @@ export class AIClient {
           model: this.model,
           max_tokens: 1024,
           messages,
-          system: SYSTEM_PROMPT,
+          system: this.basePrompt,
           tools: [...AITools],
           betas: ["computer-use-2024-10-22"]
         });

--- a/packages/shortest/src/ai/client.ts
+++ b/packages/shortest/src/ai/client.ts
@@ -5,14 +5,24 @@ import { BrowserTool } from '../browser/core/browser-tool';
 import { AITools } from './tools';
 import pc from 'picocolors';
 
-export class AIClient {
+export interface IAIClient {
+  processAction(prompt: string, browserTool: BrowserTool,
+    outputCallback?: (content: Anthropic.Beta.Messages.BetaContentBlockParam) => void,
+    toolOutputCallback?: (name: string, input: any) => void
+  ): Promise<{
+    messages: Anthropic.Beta.Messages.BetaMessageParam[];
+    finalResponse: Anthropic.Beta.Messages.BetaMessage;
+  } | null>;
+}
+
+export class AIClient implements IAIClient {
   private client: Anthropic;
   private model: string;
   private maxMessages: number;
   private debugMode: boolean;
   public basePrompt: string;
 
-  constructor(config: AIConfig, debugMode: boolean = true) {
+  constructor(config: AIConfig, debugMode: boolean = false) {
     if (!config.apiKey) {
       throw new Error('Anthropic API key is required. Set it in shortest.config.ts or ANTHROPIC_API_KEY env var');
     }
@@ -22,7 +32,7 @@ export class AIClient {
     });
     this.model = 'claude-3-5-sonnet-20241022';
     this.maxMessages = 10;
-    this.debugMode = true;
+    this.debugMode = debugMode;
     this.basePrompt = SYSTEM_PROMPT;
   }
 
@@ -46,6 +56,7 @@ export class AIClient {
         await new Promise(r => setTimeout(r, 5000 * attempts));
       }
     }
+    return null;
   }
 
   async makeRequest(

--- a/packages/shortest/src/ai/prompts/index.ts
+++ b/packages/shortest/src/ai/prompts/index.ts
@@ -48,3 +48,18 @@ Your task is to:
 3. Return test execution results in strict JSON format: { result: "pass" | "fail", reason: string }
    For failures, provide a maximum 1-sentence reason.
 4. For click actions, provide x,y coordinates of the element to click.`;
+
+
+export const JUGDEMENT_SYSTEM_PROMPT = `You are a test automation expert making a final assertion on the test case. you need to make sure that the test case is passing or failing based on the test instructions.
+
+EXAMPLE TEST CASE:
+------------------
+Test: "Login to the app using Github login"
+Context: {"username":"argo.mohrad@gmail.com","password":"password1234"}
+Callback function: [NO_CALLBACK]
+Expect: 1. Test case to be generated within at least 20 seconds [HAS_CALLBACK]
+------------------
+
+Your task is to:
+1. Return test execution results in strict JSON format: { result: "pass" | "fail", reason: string }
+   For failures, provide a maximum 1-sentence reason.`

--- a/packages/shortest/src/ai/snapshot-client.ts
+++ b/packages/shortest/src/ai/snapshot-client.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { AIClient } from './client';
+import { AIClient, IAIClient } from './client';
 import { BrowserTool } from '../browser/core/browser-tool';
 import { ActionInput } from '../types/browser';
 import { TestContext } from '../types/test';
@@ -10,7 +10,7 @@ import pc from 'picocolors';
 import { JUGDEMENT_SYSTEM_PROMPT } from './prompts';
 
 
-export class SnapshotAIClient {
+export class SnapshotAIClient implements IAIClient {
   private client: Anthropic;
   private aiClient: AIClient;
   private snapshotDir: string;
@@ -25,7 +25,7 @@ export class SnapshotAIClient {
 
   async processAction(prompt: string, browserTool: BrowserTool): Promise<{
     finalResponse: Anthropic.Beta.Messages.BetaMessage;
-    allResponses: Anthropic.Beta.Messages.BetaMessage[];
+    messages: Anthropic.Beta.Messages.BetaMessageParam[];
   } | null> {
     // Try to get test context and name
     const testContext = (browserTool as any).testContext as TestContext;
@@ -84,9 +84,9 @@ export class SnapshotAIClient {
       });
 
       return {
-        finalResponse: response,
-        allResponses: [response]
-      } as any;
+        messages: [response],
+        finalResponse: response
+      };
 
     } catch (error) {
       console.warn(`Failed to replay snapshot for ${testName}, falling back to AI:`, error);

--- a/packages/shortest/src/ai/snapshot-client.ts
+++ b/packages/shortest/src/ai/snapshot-client.ts
@@ -35,7 +35,8 @@ export class SnapshotAIClient implements IAIClient {
       return this.aiClient.processAction(prompt, browserTool) as any;
     }
 
-    const snapshotPath = join(this.snapshotDir, `${testName}.test.snapshot.jsonl`);
+    const sanitizedTestName = testName.replace(/\//g, '_');
+    const snapshotPath = join(this.snapshotDir, `${sanitizedTestName}.test.snapshot.jsonl`);
 
     if (!existsSync(snapshotPath)) {
       return this.aiClient.processAction(prompt, browserTool) as any;
@@ -56,7 +57,7 @@ export class SnapshotAIClient implements IAIClient {
           continue;
         }
         await browserTool.execute(action);
-        await sleep(500);
+        await sleep(1000);
       }
 
       // Get final state

--- a/packages/shortest/src/ai/snapshot-client.ts
+++ b/packages/shortest/src/ai/snapshot-client.ts
@@ -1,0 +1,102 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { AIClient } from './client';
+import { BrowserTool } from '../browser/core/browser-tool';
+import { ActionInput } from '../types/browser';
+import { TestContext } from '../types/test';
+import Anthropic from '@anthropic-ai/sdk';
+import { sleep } from '@anthropic-ai/sdk/core';
+import pc from 'picocolors';
+
+const JUDGMENT_PROMPT = `You are a test result validator. Your task is to evaluate if a test passed or failed based on the final state.
+You must return a JSON response in this exact format: { "result": "pass" | "fail", "reason": "one sentence explanation" }
+
+Consider:
+1. The test's intended goal
+2. The current page state
+3. Whether all required actions were completed
+4. If the final state matches expectations
+
+Be strict in your evaluation - if there's any doubt, mark it as failed.`;
+
+export class SnapshotAIClient {
+  private client: Anthropic;
+  private aiClient: AIClient;
+  private snapshotDir: string;
+
+  constructor(aiClient: AIClient) {
+    this.aiClient = aiClient;
+    this.client = new Anthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY || ''
+    });
+    this.snapshotDir = join(process.cwd(), '.shortest', 'snapshots');
+  }
+
+  async processAction(prompt: string, browserTool: BrowserTool): Promise<{
+    finalResponse: Anthropic.Beta.Messages.BetaMessage;
+    allResponses: Anthropic.Beta.Messages.BetaMessage[];
+  } | null> {
+    // Try to get test context and name
+    const testContext = (browserTool as any).testContext as TestContext;
+    const testName = testContext?.currentTest?.name;
+
+    if (!testName) {
+      return this.aiClient.processAction(prompt, browserTool) as any;
+    }
+
+    const snapshotPath = join(this.snapshotDir, `${testName}.test.snapshot.jsonl`);
+
+    if (!existsSync(snapshotPath)) {
+      return this.aiClient.processAction(prompt, browserTool) as any;
+    }
+
+    try {
+      // Read and parse the snapshot file
+      const actions = readFileSync(snapshotPath, 'utf-8')
+        .split('\n')
+        .filter(Boolean)
+        .map(line => JSON.parse(line) as ActionInput);
+
+      console.log(pc.cyan('\n📼 Replaying recorded actions...'));
+      
+      // Execute each recorded action
+      for (const action of actions) {
+        await browserTool.execute(action);
+        await sleep(1000);
+      }
+
+      // Get final state
+      const finalState = await browserTool.execute({ action: 'screenshot' });
+      
+      // Prepare judgment prompt
+      const judgmentPrompt = [
+        `Test: "${testName}"`,
+        prompt ? `Original Instructions: ${prompt}` : '',
+        '\nFinal Page State:',
+        `URL: ${finalState.metadata?.window_info?.url || 'unknown'}`,
+        `Title: ${finalState.metadata?.window_info?.title || 'unknown'}`,
+        '\nPlease evaluate if the test passed or failed.'
+      ].filter(Boolean).join('\n');
+
+      // Get judgment from Claude
+      const response = await this.client.beta.messages.create({
+        model: 'claude-3-5-sonnet-20241022',
+        max_tokens: 1024,
+        messages: [{
+          role: 'user',
+          content: judgmentPrompt
+        }],
+        system: JUDGMENT_PROMPT
+      });
+
+      return {
+        finalResponse: response,
+        allResponses: [response]
+      } as any;
+
+    } catch (error) {
+      console.warn(`Failed to replay snapshot for ${testName}, falling back to AI:`, error);
+      return this.aiClient.processAction(prompt, browserTool) as any;
+    }
+  }
+} 

--- a/packages/shortest/src/ai/snapshot-client.ts
+++ b/packages/shortest/src/ai/snapshot-client.ts
@@ -7,17 +7,8 @@ import { TestContext } from '../types/test';
 import Anthropic from '@anthropic-ai/sdk';
 import { sleep } from '@anthropic-ai/sdk/core';
 import pc from 'picocolors';
+import { JUGDEMENT_SYSTEM_PROMPT } from './prompts';
 
-const JUDGMENT_PROMPT = `You are a test result validator. Your task is to evaluate if a test passed or failed based on the final state.
-You must return a JSON response in this exact format: { "result": "pass" | "fail", "reason": "one sentence explanation" }
-
-Consider:
-1. The test's intended goal
-2. The current page state
-3. Whether all required actions were completed
-4. If the final state matches expectations
-
-Be strict in your evaluation - if there's any doubt, mark it as failed.`;
 
 export class SnapshotAIClient {
   private client: Anthropic;
@@ -61,8 +52,11 @@ export class SnapshotAIClient {
       
       // Execute each recorded action
       for (const action of actions) {
+        if (action.action === 'screenshot') {
+          continue;
+        }
         await browserTool.execute(action);
-        await sleep(1000);
+        await sleep(500);
       }
 
       // Get final state
@@ -86,7 +80,7 @@ export class SnapshotAIClient {
           role: 'user',
           content: judgmentPrompt
         }],
-        system: JUDGMENT_PROMPT
+        system: JUGDEMENT_SYSTEM_PROMPT
       });
 
       return {

--- a/packages/shortest/src/browser/actions/debug.ts
+++ b/packages/shortest/src/browser/actions/debug.ts
@@ -1,0 +1,35 @@
+import { Page } from 'playwright';
+import * as actions from './index';
+
+// Re-export keyboard shortcuts
+export const keyboardShortcuts = actions.keyboardShortcuts;
+export const scaleRatio = actions.scaleRatio;
+
+export async function mouseMove(page: Page, x: number, y: number): Promise<void> {
+  console.log(`🖱️ Mouse Move: (${x}, ${y})`);
+  await actions.mouseMove(page, x, y);
+}
+
+export async function click(page: Page, x: number, y: number): Promise<void> {
+  console.log(`🖱️ Click: (${x}, ${y})`);
+  await actions.click(page, x, y);
+}
+
+export async function dragMouse(page: Page, x: number, y: number): Promise<void> {
+  console.log(`🖱️ Drag Mouse: (${x}, ${y})`);
+  await actions.dragMouse(page, x, y);
+}
+
+export async function showClickAnimation(
+  page: Page, 
+  type: 'left' | 'right' | 'double' = 'left'
+): Promise<void> {
+  console.log(`🖱️ Show Click Animation: ${type}`);
+  await actions.showClickAnimation(page, type);
+}
+
+export async function getCursorPosition(page: Page): Promise<[number, number]> {
+  const position = await actions.getCursorPosition(page);
+  console.log(`🖱️ Get Cursor Position: (${position[0]}, ${position[1]})`);
+  return position;
+} 

--- a/packages/shortest/src/browser/actions/index.ts
+++ b/packages/shortest/src/browser/actions/index.ts
@@ -75,31 +75,35 @@ export async function dragMouse(page: Page, x: number, y: number): Promise<void>
 }
 
 export async function showClickAnimation(page: Page, type: 'left' | 'right' | 'double' = 'left'): Promise<void> {
-  await page.evaluate((clickType) => {
-    const cursor = document.getElementById('ai-cursor');
-    if (cursor) {
-      cursor.classList.add('clicking');
-      
-      switch (clickType) {
-        case 'double':
-          cursor.style.transform = 'translate(-50%, -50%) scale(0.7)';
-          cursor.style.backgroundColor = 'rgba(255, 0, 0, 0.5)';
-          break;
-        case 'right':
-          cursor.style.borderColor = 'blue';
-          break;
-        default:
-          cursor.style.transform = 'translate(-50%, -50%) scale(0.8)';
-      }
+  try {
+    await page.evaluate((clickType) => {
+      const cursor = document.getElementById('ai-cursor');
+      if (cursor) {
+        cursor.classList.add('clicking');
+        
+        switch (clickType) {
+          case 'double':
+            cursor.style.transform = 'translate(-50%, -50%) scale(0.7)';
+            cursor.style.backgroundColor = 'rgba(255, 0, 0, 0.5)';
+            break;
+          case 'right':
+            cursor.style.borderColor = 'blue';
+            break;
+          default:
+            cursor.style.transform = 'translate(-50%, -50%) scale(0.8)';
+        }
 
-      setTimeout(() => {
-        cursor.classList.remove('clicking');
-        cursor.style.transform = 'translate(-50%, -50%) scale(1)';
-        cursor.style.backgroundColor = 'rgba(255, 0, 0, 0.2)';
-        cursor.style.borderColor = 'red';
-      }, 200);
-    }
-  }, type);
+        setTimeout(() => {
+          cursor.classList.remove('clicking');
+          cursor.style.transform = 'translate(-50%, -50%) scale(1)';
+          cursor.style.backgroundColor = 'rgba(255, 0, 0, 0.2)';
+          cursor.style.borderColor = 'red';
+        }, 200);
+      }
+    }, type);
+  } catch (error) {
+    console.error('Error showing click animation:', error);
+  }
 }
 
 export async function getCursorPosition(page: Page): Promise<[number, number]> {

--- a/packages/shortest/src/browser/core/snapshot-browser-tool.ts
+++ b/packages/shortest/src/browser/core/snapshot-browser-tool.ts
@@ -1,0 +1,55 @@
+import { writeFileSync, appendFileSync, mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { BrowserTool } from './browser-tool';
+import { ActionInput, ToolResult } from '../../types/browser';
+import { TestContext } from '../../types/test';
+
+export class SnapshotBrowserTool extends BrowserTool {
+  private snapshotDir: string;
+  private snapshotFile?: string;
+  private shouldRecord: boolean = false;
+
+  constructor(...args: ConstructorParameters<typeof BrowserTool>) {
+    super(...args);
+    
+    // Create snapshots directory
+    this.snapshotDir = join(process.cwd(), '.shortest', 'snapshots');
+    mkdirSync(this.snapshotDir, { recursive: true });
+
+    // Initialize snapshot file when test context is available
+    if (args[2].testContext?.currentTest?.name) {
+      this.initializeSnapshotFile(args[2].testContext.currentTest.name);
+    }
+  }
+
+  private initializeSnapshotFile(testName: string): void {
+    this.snapshotFile = join(this.snapshotDir, `${testName}.test.snapshot.jsonl`);
+    // Only set up recording if snapshot doesn't exist
+    this.shouldRecord = !existsSync(this.snapshotFile);
+    
+    if (this.shouldRecord) {
+      // Create/clear the file only if we're going to record
+      writeFileSync(this.snapshotFile!, '');
+    }
+  }
+
+  async execute(input: ActionInput): Promise<ToolResult> {
+    // Only record if we should and have a file
+    if (this.shouldRecord && this.snapshotFile) {
+      appendFileSync(this.snapshotFile, JSON.stringify(input) + '\n');
+    }
+
+    console.log(`\n🔍 Executing action: ${input.action}`, input);
+    // Execute normally using parent class 
+    return super.execute(input);
+  }
+
+  updateTestContext(newContext: TestContext): void {
+    super.updateTestContext(newContext);
+    
+    // Initialize new snapshot file when test changes
+    if (newContext?.currentTest?.name) {
+      this.initializeSnapshotFile(newContext.currentTest.name);
+    }
+  }
+} 

--- a/packages/shortest/src/browser/core/snapshot-browser-tool.ts
+++ b/packages/shortest/src/browser/core/snapshot-browser-tool.ts
@@ -23,7 +23,8 @@ export class SnapshotBrowserTool extends BrowserTool {
   }
 
   private initializeSnapshotFile(testName: string): void {
-    this.snapshotFile = join(this.snapshotDir, `${testName}.test.snapshot.jsonl`);
+    const sanitizedTestName = testName.replace(/\//g, '_');
+    this.snapshotFile = join(this.snapshotDir, `${sanitizedTestName}.test.snapshot.jsonl`);
     // Only set up recording if snapshot doesn't exist
     this.shouldRecord = !existsSync(this.snapshotFile);
     

--- a/packages/shortest/src/browser/core/snapshot-browser-tool.ts
+++ b/packages/shortest/src/browser/core/snapshot-browser-tool.ts
@@ -7,7 +7,7 @@ import { TestContext } from '../../types/test';
 export class SnapshotBrowserTool extends BrowserTool {
   private snapshotDir: string;
   private snapshotFile?: string;
-  private shouldRecord: boolean = false;
+  public shouldRecord: boolean = false;
 
   constructor(...args: ConstructorParameters<typeof BrowserTool>) {
     super(...args);

--- a/packages/shortest/src/core/runner/index.ts
+++ b/packages/shortest/src/core/runner/index.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path';
 import { TestCompiler } from '../compiler';
 import { BrowserManager } from '../../browser/manager';
 import { BrowserTool } from '../../browser/core/browser-tool';
+import { SnapshotBrowserTool } from '../../browser/core/snapshot-browser-tool';
 import { AIClient } from '../../ai/client';
 import { initialize, getConfig } from '../../index';
 import { TestFunction, TestContext, ShortestConfig } from '../../types';
@@ -12,6 +13,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { APIRequest, BrowserContext } from 'playwright';
 import * as playwright from 'playwright';
 import { request, chromium, APIRequestContext } from 'playwright';
+import { SnapshotAIClient } from '../../ai/snapshot-client';
 
 interface TestResult {
   result: 'pass' | 'fail';
@@ -152,7 +154,7 @@ export class TestRunner {
 
     // Use the shared context
     const testContext = await this.createTestContext(context);
-    const browserTool = new BrowserTool(testContext.page, this.browserManager, {
+    const browserTool = new SnapshotBrowserTool(testContext.page, this.browserManager, {
       width: 1920,
       height: 1080,
       testContext: {
@@ -162,12 +164,14 @@ export class TestRunner {
       }
     });
 
-    const aiClient = new AIClient({
+    const baseAiClient = new AIClient({
       apiKey: this.config.anthropicKey,
       model: 'claude-3-5-sonnet-20241022',
       maxMessages: 10,
       debug: this.debugAI
     }, this.debugAI);
+
+    const aiClient = new SnapshotAIClient(baseAiClient);
 
     // First get page state
     const initialState = await browserTool.execute({ 

--- a/packages/shortest/src/core/runner/index.ts
+++ b/packages/shortest/src/core/runner/index.ts
@@ -4,7 +4,7 @@ import { TestCompiler } from '../compiler';
 import { BrowserManager } from '../../browser/manager';
 import { BrowserTool } from '../../browser/core/browser-tool';
 import { SnapshotBrowserTool } from '../../browser/core/snapshot-browser-tool';
-import { AIClient } from '../../ai/client';
+import { AIClient, IAIClient } from '../../ai/client';
 import { initialize, getConfig } from '../../index';
 import { TestFunction, TestContext, ShortestConfig } from '../../types';
 import { Logger } from '../../utils/logger';
@@ -171,7 +171,12 @@ export class TestRunner {
       debug: this.debugAI
     }, this.debugAI);
 
-    const aiClient = new SnapshotAIClient(baseAiClient);
+    let aiClient: IAIClient;
+    if (!browserTool.shouldRecord) {
+      aiClient = new SnapshotAIClient(baseAiClient);
+    } else {
+      aiClient = baseAiClient;
+    }
 
     // First get page state
     const initialState = await browserTool.execute({ 

--- a/packages/shortest/src/types/browser.ts
+++ b/packages/shortest/src/types/browser.ts
@@ -71,6 +71,7 @@ export interface BrowserToolConfig {
   width: number;
   height: number;
   testContext?: TestContext;
+  debug?: boolean;
 }
 
 export type BetaToolType = 


### PR DESCRIPTION
Some stuff is still quite irrelevant as I was trying out the repo...

1. Made a SnapshotBrowserTool that records the steps taken by the AI.
2. Made a SnapshotAIClient that makes a final decision after all the recorded steps are rerun from the snapshot file (JSONL)

I need to clean it up, would be useful to ignore the screenshot steps, and maybe add a wait for load after clicking or navigating instead of a 1s sleep.

Also a --snapshot parameter should be added and a cleanup parameter as well.

Speed is clearly better, and the AI still makes the final judgement call with a different prompt.