### PR TITLE
fix: fix incorrect path for types in index.d.ts

### DIFF
--- a/packages/shortest/index.d.ts
+++ b/packages/shortest/index.d.ts
@@ -1,8 +1,8 @@
 import type { Expect } from "expect";
 import type { Page, Browser, APIRequest, APIRequestContext } from "playwright";
 import type * as playwright from "playwright";
-import type { ShortestConfig } from "./dist/types/config";
-import type { TestAPI, TestContext } from "./dist/types/test";
+import type { ShortestConfig } from "./dist/types/types/config";
+import type { TestAPI, TestContext } from "./dist/types/types/test";
 
 declare global {
   const expect: Expect;


### PR DESCRIPTION
Fixs #191 

**Changes**

Previously when the package is bundled, `index.d.ts` had incorrect paths for some imports. this makes the `ShortestConfig` from `@antiwork/shortest` not resolve properly.

here's the file structure of the published package ( i've removed irrelevent files from the tree ) 

```
@antiwork/shortest/
├── dist/
│   └── types/
│       └── types/
│           ├── config.d.ts
│           └── test.d.ts
└── index.d.ts
```

so the imports in `index.d.ts` had two wrong imports
* `./dist/types/test`
* `./dist/types/config`

both will not resolve, the correct paths are 
* `./dist/types/types/test`
* `./dist/types/types/config`

this PR makes that update.

note: as discussed in the issue, there are room for improvement in the generation of `index.d.ts`. I'm gathering context for that. but since this is a rather important fix (imo). raising a PR. 
