### PR TITLE
feat: enable bash tool for computer use

### DIFF
--- a/examples/curl.test.ts
+++ b/examples/curl.test.ts
@@ -1,0 +1,5 @@
+import { shortest } from "@antiwork/shortest";
+
+shortest("run a request to /posts/1 and verify the post is created by user 1", {
+  url: "https://jsonplaceholder.typicode.com",
+});

--- a/packages/shortest/src/ai/client.ts
+++ b/packages/shortest/src/ai/client.ts
@@ -130,7 +130,10 @@ export class AIClient {
             ) {
               return {
                 toolBlock,
-                result: runBashCommand(input.command),
+                result: browserTool.execute({
+                  action: "bash",
+                  command: input.command,
+                }),
               };
             }
 

--- a/packages/shortest/src/ai/client.ts
+++ b/packages/shortest/src/ai/client.ts
@@ -119,6 +119,21 @@ export class AIClient {
             response.content.filter((block) => block.type === "tool_use");
 
           const toolResults = toolBlocks.map((toolBlock) => {
+            const isBash = toolBlock.name === "bash";
+            const input = toolBlock.input;
+
+            if (
+              isBash &&
+              input instanceof Object &&
+              "command" in input &&
+              typeof input.command === "string"
+            ) {
+              return {
+                toolBlock,
+                result: runBashCommand(input.command),
+              };
+            }
+
             return {
               toolBlock,
 

--- a/packages/shortest/src/ai/prompts/index.ts
+++ b/packages/shortest/src/ai/prompts/index.ts
@@ -52,10 +52,10 @@ IMPORTANT GLOBAL RULES:
    - You MUST pass the email address that is given to you to the tool as a parameter otherwise it will fail.
    - If no email address is given to you for this test, you should fail the test.
 
-9. **Bash Commands**:
-   - you have access to a bash tool to run bash commands
-   - only use tools that are usually available in a bash terminal, unless explicitly stated otherwise by the prompt
-   - make sure to consider the OS you are working on when generating the bash commands, the OS you are currently working on is: ${platform}
+9. **Curl Commands**:
+   - you have access to a bash tool to run curl commands
+   - only run curl commands using the bash tool, do not run any other bash commands
+   - make sure to consider the OS you are working on when generating the curl commands, the OS you are currently working on is: ${platform}
 
 Your task is to:
 1. Execute browser actions to validate test cases

--- a/packages/shortest/src/ai/prompts/index.ts
+++ b/packages/shortest/src/ai/prompts/index.ts
@@ -1,3 +1,7 @@
+import os from "os";
+
+const platform = os.platform();
+
 export const SYSTEM_PROMPT = `You are a test automation expert working with a Chrome browser. You will be given test instructions, and your task is to execute specified browser actions to validate the provided test cases. You are already in the Chrome browser and on the relevant application page, so there is no need to open or initialize the browser yourself.
 
 EXAMPLE TEST CASE:
@@ -47,6 +51,11 @@ IMPORTANT GLOBAL RULES:
    - Once you are done with validating the email, navigate back to the original tab.
    - You MUST pass the email address that is given to you to the tool as a parameter otherwise it will fail.
    - If no email address is given to you for this test, you should fail the test.
+
+9. **Bash Commands**:
+   - you have access to a bash tool to run bash commands
+   - only use tools that are usually available in a bash terminal, unless explicitly stated otherwise by the prompt
+   - make sure to consider the OS you are working on when generating the bash commands, the OS you are currently working on is: ${platform}
 
 Your task is to:
 1. Execute browser actions to validate test cases

--- a/packages/shortest/src/ai/tools/index.ts
+++ b/packages/shortest/src/ai/tools/index.ts
@@ -1,5 +1,6 @@
 import { exec } from "child_process";
 import { promisify } from "util";
+import { ToolResult } from "../../types";
 
 export const AITools = [
   {
@@ -113,16 +114,20 @@ export const AITools = [
 
 export type AITool = (typeof AITools)[number]["name"];
 
-export const runBashCommand = async (command: string) => {
+export const runBashCommand = async (command: string): Promise<ToolResult> => {
   try {
     const res = await promisify(exec)(command);
 
-    return res;
+    return {
+      output: JSON.stringify(res),
+    };
   } catch (e) {
     // not throwing and returning the error message, because may be claude can update the command based on the error message
     return {
+      output: JSON.stringify({
       message: "Error running the bash command",
       error: e,
+      }),
     };
   }
 };

--- a/packages/shortest/src/ai/tools/index.ts
+++ b/packages/shortest/src/ai/tools/index.ts
@@ -1,3 +1,6 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+
 export const AITools = [
   {
     type: "computer_20241022",
@@ -101,6 +104,10 @@ export const AITools = [
       },
       required: ["action", "url"],
     },
+  },
+  {
+    type: "bash_20241022",
+    name: "bash",
   },
 ] as const;
 

--- a/packages/shortest/src/ai/tools/index.ts
+++ b/packages/shortest/src/ai/tools/index.ts
@@ -112,6 +112,10 @@ export const runBashCommand = async (command: string) => {
 
     return res;
   } catch (e) {
-    throw new Error(`Error running bash command: ${e}`);
+    // not throwing and returning the error message, because may be claude can update the command based on the error message
+    return {
+      message: "Error running the bash command",
+      error: e,
+    };
   }
 };

--- a/packages/shortest/src/ai/tools/index.ts
+++ b/packages/shortest/src/ai/tools/index.ts
@@ -105,3 +105,13 @@ export const AITools = [
 ] as const;
 
 export type AITool = (typeof AITools)[number]["name"];
+
+export const runBashCommand = async (command: string) => {
+  try {
+    const res = await promisify(exec)(command);
+
+    return res;
+  } catch (e) {
+    throw new Error(`Error running bash command: ${e}`);
+  }
+};

--- a/packages/shortest/src/ai/tools/index.ts
+++ b/packages/shortest/src/ai/tools/index.ts
@@ -1,7 +1,3 @@
-import { exec } from "child_process";
-import { promisify } from "util";
-import { ToolResult } from "../../types";
-
 export const AITools = [
   {
     type: "computer_20241022",
@@ -113,21 +109,3 @@ export const AITools = [
 ] as const;
 
 export type AITool = (typeof AITools)[number]["name"];
-
-export const runBashCommand = async (command: string): Promise<ToolResult> => {
-  try {
-    const res = await promisify(exec)(command);
-
-    return {
-      output: JSON.stringify(res),
-    };
-  } catch (e) {
-    // not throwing and returning the error message, because may be claude can update the command based on the error message
-    return {
-      output: JSON.stringify({
-      message: "Error running the bash command",
-      error: e,
-      }),
-    };
-  }
-};

--- a/packages/shortest/src/browser/core/browser-tool.ts
+++ b/packages/shortest/src/browser/core/browser-tool.ts
@@ -7,6 +7,7 @@ declare global {
   }
 }
 
+import { exec } from "child_process";
 import {
   writeFileSync,
   mkdirSync,
@@ -15,6 +16,7 @@ import {
   unlinkSync,
 } from "fs";
 import { join } from "path";
+import { promisify } from "util";
 import pc from "picocolors";
 import { Page } from "playwright";
 import { initialize, getConfig } from "../../index";

--- a/packages/shortest/src/browser/core/browser-tool.ts
+++ b/packages/shortest/src/browser/core/browser-tool.ts
@@ -852,7 +852,7 @@ export class BrowserTool extends BaseBrowserTool {
           "alt",
           "d", // for <path> tags
         ],
-      }
+      },
     );
   }
 }

--- a/packages/shortest/src/browser/core/browser-tool.ts
+++ b/packages/shortest/src/browser/core/browser-tool.ts
@@ -537,6 +537,14 @@ export class BrowserTool extends BaseBrowserTool {
           }
         }
 
+        case "bash": {
+          if (!input.command) {
+            throw new ToolError("Command required for bash action");
+          }
+
+          return await runBashCommand(input.command);
+        }
+
         default:
           throw new ToolError(`Unknown action: ${input.action}`);
       }
@@ -842,7 +850,25 @@ export class BrowserTool extends BaseBrowserTool {
           "alt",
           "d", // for <path> tags
         ],
-      },
+      }
     );
   }
 }
+
+export const runBashCommand = async (command: string): Promise<ToolResult> => {
+  try {
+    const res = await promisify(exec)(command);
+
+    return {
+      output: JSON.stringify(res),
+    };
+  } catch (e) {
+    // not throwing and returning the error message, because may be claude can update the command based on the error message
+    return {
+      output: JSON.stringify({
+        message: "Error running the bash command",
+        error: e,
+      }),
+    };
+  }
+};

--- a/packages/shortest/src/core/runner/index.ts
+++ b/packages/shortest/src/core/runner/index.ts
@@ -444,6 +444,14 @@ export class TestRunner {
           step.action?.input.action !== BrowserActionEnum.Screenshot.toString(),
       );
 
+    const hasBashSteps = steps?.some((step) => step.action?.name === "bash");
+
+    if (hasBashSteps) {
+      throw new Error(
+        "Tests having bash commands are not supported in cached mode, running test in normal mode"
+      );
+    }
+
     if (!steps) {
       throw new Error("No steps to execute running test in a normal mode");
     }

--- a/packages/shortest/src/core/runner/index.ts
+++ b/packages/shortest/src/core/runner/index.ts
@@ -264,6 +264,14 @@ export class TestRunner {
           // reset window state
           const page = browserTool.getPage();
           await page.goto(initialState.metadata?.window_info?.url!);
+
+          // print that the cache run failed due to some reason,
+          console.log(
+            pc.yellow(
+              `Cache run failed for test ${hashData(test)}, running test in normal mode`,
+            ),
+          );
+
           await this.executeTest(test, context, {
             noCache: true,
           });

--- a/packages/shortest/src/core/runner/index.ts
+++ b/packages/shortest/src/core/runner/index.ts
@@ -448,7 +448,7 @@ export class TestRunner {
 
     if (hasBashSteps) {
       throw new Error(
-        "Tests having bash commands are not supported in cached mode, running test in normal mode"
+        "Tests having bash commands are not supported in cached mode, running test in normal mode",
       );
     }
 

--- a/packages/shortest/src/types/browser.ts
+++ b/packages/shortest/src/types/browser.ts
@@ -30,6 +30,7 @@ export enum BrowserActionEnum {
   Navigate = "navigate",
   Sleep = "sleep",
   CheckMail = "check_email",
+  Bash = "bash",
 }
 
 export type BrowserAction = `${BrowserActionEnum}`;
@@ -50,6 +51,7 @@ export interface ActionInput {
   url?: string;
   duration?: number;
   email?: string;
+  command?: string;
 }
 
 export interface ToolResult {


### PR DESCRIPTION
Fixes #226 

**Changes**

1. This PR adds support for the `bash` tool that's supported by anthropic computer use.
2. For cached tests having bash tools, they're rerun without caching


https://github.com/user-attachments/assets/ac477074-976f-4dfe-ab60-330967ec2096

