### PR TITLE
Update shortest.config.ts

### DIFF
--- a/shortest.config.ts
+++ b/shortest.config.ts
@@ -3,7 +3,7 @@ import type { ShortestConfig } from "@antiwork/shortest";
 export default {
   headless: false,
   baseUrl: "http://localhost:3000",
-  testPattern: "**/*.test.ts",
+  testPattern: "app/**/*.test.ts", // Don't test example tests
   anthropicKey: process.env.ANTHROPIC_API_KEY,
   mailosaur: {
     apiKey: process.env.MAILOSAUR_API_KEY,


### PR DESCRIPTION
Why: So we can ensure a green build on specs we can fully control. The examples can remain examples for others.