### PR TITLE
feat: add baseURL configuration to BrowserManager context

### DIFF
--- a/packages/shortest/src/browser/manager/index.ts
+++ b/packages/shortest/src/browser/manager/index.ts
@@ -53,6 +53,7 @@ export class BrowserManager {
 
     this.context = await this.browser.newContext({
       viewport: { width: 1920, height: 1080 },
+      baseURL: this.config.baseUrl,
     });
 
     const page = await this.context.newPage();


### PR DESCRIPTION
I figured it makes sense that, page.goto, should allow for relative paths like "/dashboard" instead of having to define the full url. It assumes that relative paths are using the baseUrl defined in the config.