### PR TITLE
Updated reame with CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,18 +238,13 @@ jobs:
       - name: Start dev server
         run: pnpm dev & sleep 1
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           PORT: 3000
 
       - name: Run Shortest tests
         run: npx shortest src/__tests__/**/*.test.ts --headless
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           PLAYWRIGHT_TEST_BASE_URL: "http://localhost:8080"
-          SHORTEST_DISABLE_SCREENSHOTS: "true"
           # Add these if you're using GitHub auth in your tests
           # GITHUB_USERNAME: ${{ secrets.TEST_GITHUB_USERNAME }}
           # GITHUB_PASSWORD: ${{ secrets.TEST_GITHUB_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -195,6 +195,68 @@ You can find example tests in the [`examples`](./examples) directory.
 
 You can run Shortest in your CI/CD pipeline by running tests in headless mode. Make sure to add your Anthropic API key to your CI/CD pipeline secrets.
 
+Example CLI YML script:
+```
+name: Shortest Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright
+        run: |
+          npm install -g playwright
+          playwright install chromium
+
+      - name: Setup Shortest directory
+        run: |
+          mkdir -p .shortest
+          chmod -R 777 .shortest
+
+      - name: Start dev server
+        run: pnpm dev & sleep 1
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          PORT: 3000
+
+      - name: Run Shortest tests
+        run: npx shortest src/__tests__/**/*.test.ts --headless
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          PLAYWRIGHT_TEST_BASE_URL: "http://localhost:8080"
+          SHORTEST_DISABLE_SCREENSHOTS: "true"
+          # Add these if you're using GitHub auth in your tests
+          # GITHUB_USERNAME: ${{ secrets.TEST_GITHUB_USERNAME }}
+          # GITHUB_PASSWORD: ${{ secrets.TEST_GITHUB_PASSWORD }}
+          # GITHUB_TOTP_SECRET: ${{ secrets.GITHUB_TOTP_SECRET }}
+
+```
+
 ### GitHub 2FA login setup
 
 Shortest supports login using GitHub 2FA. For GitHub authentication tests:

--- a/README.md
+++ b/README.md
@@ -195,62 +195,7 @@ You can find example tests in the [`examples`](./examples) directory.
 
 You can run Shortest in your CI/CD pipeline by running tests in headless mode. Make sure to add your Anthropic API key to your CI/CD pipeline secrets.
 
-Example CLI YML script:
-```
-name: Shortest Tests
-
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Install Playwright
-        run: |
-          npm install -g playwright
-          playwright install chromium
-
-      - name: Setup Shortest directory
-        run: |
-          mkdir -p .shortest
-          chmod -R 777 .shortest
-
-      - name: Start dev server
-        run: pnpm dev & sleep 1
-        env:
-          PORT: 3000
-
-      - name: Run Shortest tests
-        run: npx shortest src/__tests__/**/*.test.ts --headless
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          PLAYWRIGHT_TEST_BASE_URL: "http://localhost:8080"
-          # Add these if you're using GitHub auth in your tests
-          # GITHUB_USERNAME: ${{ secrets.TEST_GITHUB_USERNAME }}
-          # GITHUB_PASSWORD: ${{ secrets.TEST_GITHUB_PASSWORD }}
-          # GITHUB_TOTP_SECRET: ${{ secrets.GITHUB_TOTP_SECRET }}
-
-```
+![See example here](https://github.com/anti-work/shortest/blob/main/.github/workflows/shortest.yml)
 
 ### GitHub 2FA login setup
 


### PR DESCRIPTION
What:

The readme has no CLI example.

Why:

Its hard for users to understand how to setup shortest with CLI, especially if they have no technical experience doing this prior. 