### PR TITLE
chore(cli): Rename `pkg` prefix to `cli` and improve docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env
 .env.local
 .env*.local
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.local
 .env*.local
 

--- a/README.md
+++ b/README.md
@@ -379,16 +379,16 @@ Open [http://localhost:3000](http://localhost:3000) in your browser to see the a
 
 2. Test changes instantly during development (no build needed):
 ```bash
-pnpm pkg:test:src -h
+pnpm cli:test:src -h
 ```
 
 3. To test the actual built package:
 ```bash
 # One-time build
-pnpm pkg:build
+pnpm cli:build
 
 # Watch mode (rebuilds on changes)
-pnpm pkg:dev
+pnpm cli:dev
 
 # Test changes
 pnpm shortest --help

--- a/lib/db/drizzle.ts
+++ b/lib/db/drizzle.ts
@@ -3,7 +3,6 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "@/lib/db/schema";
 
-// Load .env and .env.local
 dotenv.config({ path: ".env.local" });
 
 if (!process.env.POSTGRES_URL) {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "stripe:webhooks": "stripe listen --forward-to http://localhost:3000/api/stripe/webhook",
     "setup": "npx tsx lib/setup.ts",
 
-    "pkg:build": "cd packages/shortest && pnpm build",
-    "pkg:dev": "cd packages/shortest && pnpm dev",
-    "pkg:test": "cd packages/shortest && pnpm shortest",
-    "pkg:test:src": "npx tsx packages/shortest/src/cli/bin.ts",
+    "cli:build": "cd packages/shortest && pnpm build",
+    "cli:dev": "cd packages/shortest && pnpm dev",
+    "cli:test": "cd packages/shortest && pnpm shortest",
+    "cli:test:src": "npx tsx packages/shortest/src/cli/bin.ts",
 
     "test": "pnpm shortest",
     "lint": "eslint .",

--- a/packages/shortest/CONTRIBUTING.md
+++ b/packages/shortest/CONTRIBUTING.md
@@ -50,6 +50,9 @@ pnpm cli:build
 3. Update CHANGELOG.md with your changes
 4. Make sure all tests pass
 5. Request a review from maintainers
+6. After reviews begin, avoid force-pushing to your branch
+   - Force-pushing rewrites history and makes review threads hard to follow
+   - Don't worry about messy commits - we squash everything when merging to `main`
 
 ## Style guide
 

--- a/packages/shortest/CONTRIBUTING.md
+++ b/packages/shortest/CONTRIBUTING.md
@@ -2,84 +2,88 @@
 
 Thanks for your interest in contributing! This document will help you get started.
 
-## Development Setup
+## Quick start
 
-1. Clone and Install
+1. Set up the repository
 ```bash
 git clone https://github.com/anti-work/shortest.git
 cd shortest
 pnpm install
 ```
 
-2. Setup CLI Locally
+2. Link CLI for local development
 ```bash
-cd packages/shortest
-pnpm link --global
-cd ../..
-pnpm link --global shortest
+cd packages/shortest && pnpm link --global
+cd ../.. && pnpm link --global shortest
 ```
 
-3. Environment Setup
+3. Configure environment
 ```bash
 cp .env.example .env.local
 # Add your ANTHROPIC_API_KEY to .env.local
 ```
 
-## Development Workflow
+## Development
 
-1. Create a new branch
+1. Create your feature branch
 ```bash
 git checkout -b feature/your-feature
 ```
 
-2. Run Tests
+2. Run the test suite
 ```bash
 pnpm test:ai
 pnpm test:browser
-pnpm test:coordinates
 pnpm test:github
 pnpm test:assertion
 ```
 
-3. Build Package
+3. Build the CLI package
 ```bash
-pnpm pkg:build
+pnpm cli:build
 ```
 
-## Pull Request Process
+## Pull requests
 
-1. Bump the version if needed
-2. Update documentation if needed
-3. Add or update tests
-4. Update CHANGELOG.md
-5. Ensure all tests pass
-6. Request review
+1. Update documentation if you're changing behavior
+2. Add or update tests for your changes
+3. Update CHANGELOG.md with your changes
+4. Make sure all tests pass
+5. Request a review from maintainers
 
-## Code Style
+## Style guide
 
-- Use TypeScript
-- Follow existing code style
-- Use meaningful variable names
+- Write in TypeScript
+- Follow the existing code patterns
+- Use clear, descriptive variable names
 
-## Commit Messages
+## Writing commit messages
 
-Format: `type(scope): message`
+We use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 
-Types:
-- feat: New feature
-- fix: Bug fix
-- docs: Documentation
-- chore: Maintenance
-- test: Tests
-- refactor: Code refactoring
+A commit message should be structured as follows:
+
+```bash
+type(scope): title
+
+description
+```
+
+Where type can be:
+* `feat`: new feature or enhancement
+* `fix`: bug fixes
+* `docs`: documentation-only changes
+* `test`: test-only changes
+* `refactor`: code improvements without behaviour changes
+* `chore`: maintenance/anything else
 
 Example:
 ```
-feat(browser): add support for iframe handling
+feat(cli): Add mobile testing support
 ```
 
-## Need Help?
+## Help
 
-- Open an issue for bugs
-- Start a discussion for features
-- Check existing issues and PRs
+- Check existing discussions/issues/PRs before creating new ones
+- Start a discussion for questions or ideas
+- Open an issue for bugs or problems

--- a/packages/shortest/src/browser/integrations/github.ts
+++ b/packages/shortest/src/browser/integrations/github.ts
@@ -16,7 +16,7 @@ export class GitHubTool {
   };
 
   constructor(secret?: string) {
-    dotenv.config({ path: ".env.local" });
+    dotenv.config({ path: [".env", ".env.local"] });
 
     this.totpSecret = secret || process.env.GITHUB_TOTP_SECRET || "";
 

--- a/packages/shortest/src/index.ts
+++ b/packages/shortest/src/index.ts
@@ -41,6 +41,7 @@ if (!global.__shortest__) {
   // Attach to global scope
   global.expect = global.__shortest__.expect;
 
+  dotenv.config({ path: join(process.cwd(), ".env") });
   dotenv.config({ path: join(process.cwd(), ".env.local") });
 }
 
@@ -64,6 +65,7 @@ function validateConfig(config: Partial<ShortestConfig>) {
 export async function initialize() {
   if (globalConfig) return globalConfig;
 
+  dotenv.config({ path: join(process.cwd(), ".env") });
   dotenv.config({ path: join(process.cwd(), ".env.local") });
 
   const configFiles = [


### PR DESCRIPTION
* Use `cli:` as prefix for CLI-specific scripts
* Update CONTRIBUTING
* Add support back for `.env` for the CLI (removed in https://github.com/anti-work/shortest/pull/273)

### Why

`pkg` is too generic. Using `cli` is more intuitive that the scripts are associated with the CLI tool.