### PR TITLE
fix(cli): Propagate failures around parsing AI response

### DIFF
--- a/.github/workflows/shortest.yml
+++ b/.github/workflows/shortest.yml
@@ -36,7 +36,7 @@ jobs:
           cp .vercel/.env.preview.local .env.local
           test -f .env.local || (echo ".env.local not created" && exit 1)
 
-      - name: Setup database
+      - name: Set up database
         run: |
           pnpm drizzle-kit generate
           pnpm db:migrate

--- a/packages/shortest/src/core/runner/index.ts
+++ b/packages/shortest/src/core/runner/index.ts
@@ -280,7 +280,11 @@ export class TestRunner {
     const result = await aiClient.processAction(prompt, browserTool);
 
     if (!result) {
-      throw new Error("AI processing failed: no result returned");
+      return {
+        result: "fail" as const,
+        reason: "AI processing failed: no result returned",
+        tokenUsage: { input: 0, output: 0 },
+      };
     }
 
     // Parse AI result first
@@ -293,14 +297,22 @@ export class TestRunner {
     );
 
     if (!finalMessage || finalMessage.type !== "text") {
-      throw new Error("No test result found in AI response");
+      return {
+        result: "fail" as const,
+        reason: "No test result found in AI response",
+        tokenUsage: result.tokenUsage,
+      };
     }
 
     const jsonMatch = (
       finalMessage as Anthropic.Beta.Messages.BetaTextBlock
     ).text.match(/{[\s\S]*}/);
     if (!jsonMatch) {
-      throw new Error("Invalid test result format");
+      return {
+        result: "fail" as const,
+        reason: "Invalid test result format",
+        tokenUsage: result.tokenUsage,
+      };
     }
 
     const aiResult = JSON.parse(jsonMatch[0]) as TestResult;


### PR DESCRIPTION
Noticed on Iffy that the test failures didn't return proper status code, and the CI step didn't fail

![CleanShot 2025-01-15 at 16 01 22@2x](https://github.com/user-attachments/assets/d49a1670-a5a2-480e-9273-e3bf73e59a39)
