### PR TITLE
chore(cli): Remove `cli:test:src` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,12 +377,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser to see the a
 
 1. Make changes to the package source code in `packages/shortest/`
 
-2. Test changes instantly during development (no build needed):
-```bash
-pnpm cli:test:src -h
-```
-
-3. To test the actual built package:
+2. Build the package and test the changes:
 ```bash
 # One-time build
 pnpm cli:build
@@ -394,7 +389,7 @@ pnpm cli:dev
 pnpm shortest --help
 ```
 
-4. To test in another project:
+3. To test in another project:
 ```bash
 # In Shortest package directory
 cd packages/shortest

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "cli:build": "cd packages/shortest && pnpm build",
     "cli:dev": "cd packages/shortest && pnpm dev",
     "cli:test": "cd packages/shortest && pnpm shortest",
-    "cli:test:src": "npx tsx packages/shortest/src/cli/bin.ts",
 
     "test": "pnpm shortest",
     "lint": "eslint .",


### PR DESCRIPTION
Is currently broken, see https://github.com/anti-work/shortest/issues/276