### PR TITLE
chore(refactor): rename Logger to TestReporter

### DIFF
--- a/packages/shortest/src/cache/cache.ts
+++ b/packages/shortest/src/cache/cache.ts
@@ -1,15 +1,15 @@
 import * as fs from "fs";
 import path from "path";
+import { TestReporter } from "../core/runner/test-reporter";
 import { CacheEntry, CacheStore } from "../types/cache";
 import { hashData } from "../utils/crypto";
-import { Logger } from "../utils/logger";
 import * as objects from "../utils/objects";
 
 export class BaseCache<T extends CacheEntry> {
   private readonly CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 1 week
   private readonly CLEANUP_PROBABILITY = 0.03; // 3% chance
 
-  private logger: Logger;
+  private testReporter: TestReporter;
 
   private cacheFile: string;
 
@@ -20,7 +20,7 @@ export class BaseCache<T extends CacheEntry> {
   protected lockAcquireFailures = 0;
 
   constructor() {
-    this.logger = new Logger();
+    this.testReporter = new TestReporter();
     this.cacheFile = path.join(process.cwd(), ".shortest", "cache.json");
     this.lockFile = path.join(process.cwd(), ".shortest", "cache.lock");
     this.ensureDirectory();
@@ -49,7 +49,7 @@ export class BaseCache<T extends CacheEntry> {
 
   public async get(key: Record<any, any>): Promise<T | null> {
     if (!(await this.acquireLock())) {
-      this.logger.error("Cache", "Failed to acquire lock for set operation");
+      this.testReporter.error("Cache", "Failed to acquire lock for set operation");
       return null;
     }
     try {
@@ -57,7 +57,7 @@ export class BaseCache<T extends CacheEntry> {
       const cache = this.read();
       return (cache[hashedKey] as T | undefined) ?? null;
     } catch {
-      this.logger.error("Cache", "Failed to get");
+      this.testReporter.error("Cache", "Failed to get");
       return null;
     } finally {
       this.releaseLock();
@@ -69,7 +69,7 @@ export class BaseCache<T extends CacheEntry> {
     value: Partial<T["data"]>,
   ): Promise<void> {
     if (!(await this.acquireLock())) {
-      this.logger.error("Cache", "Failed to acquire lock for set operation");
+      this.testReporter.error("Cache", "Failed to acquire lock for set operation");
       return;
     }
     try {
@@ -87,7 +87,7 @@ export class BaseCache<T extends CacheEntry> {
 
       this.write(cache);
     } catch {
-      this.logger.error("Cache", "Failed to set");
+      this.testReporter.error("Cache", "Failed to set");
       this.reset();
     } finally {
       this.releaseLock();
@@ -101,7 +101,7 @@ export class BaseCache<T extends CacheEntry> {
     try {
       fs.writeFileSync(this.cacheFile, "{}");
     } catch {
-      this.logger.error("Cache", "Failed to reset");
+      this.testReporter.error("Cache", "Failed to reset");
     } finally {
       this.releaseLock();
     }
@@ -111,13 +111,13 @@ export class BaseCache<T extends CacheEntry> {
     try {
       fs.writeFileSync(this.cacheFile, JSON.stringify(cache, null, 2));
     } catch {
-      this.logger.error("Cache", "Failed to write");
+      this.testReporter.error("Cache", "Failed to write");
     }
   }
 
   public async delete(key: Record<string, any>): Promise<void> {
     if (!(await this.acquireLock())) {
-      this.logger.error("Cache", "Failed to acquire lock for delete operation");
+      this.testReporter.error("Cache", "Failed to acquire lock for delete operation");
       return;
     }
 
@@ -129,10 +129,10 @@ export class BaseCache<T extends CacheEntry> {
         delete cache[hashedKey];
         this.write(cache);
       } else {
-        this.logger.error("Cache", "Failed to delete: entry not found");
+        this.testReporter.error("Cache", "Failed to delete: entry not found");
       }
     } catch {
-      this.logger.error("Cache", "Failed to delete");
+      this.testReporter.error("Cache", "Failed to delete");
     }
   }
 
@@ -153,7 +153,7 @@ export class BaseCache<T extends CacheEntry> {
         this.write(cache);
       }
     } catch {
-      this.logger.error("Cache", "Failed to cleanup");
+      this.testReporter.error("Cache", "Failed to cleanup");
     }
   }
 
@@ -173,14 +173,14 @@ export class BaseCache<T extends CacheEntry> {
         this.lockAcquired = true;
         return true;
       } catch {
-        this.logger.error("Cache", "Failed to acquire lock");
+        this.testReporter.error("Cache", "Failed to acquire lock");
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
     }
-    this.logger.error("Cache", "Failed to acquire lock after timeout");
+    this.testReporter.error("Cache", "Failed to acquire lock after timeout");
     this.lockAcquireFailures++;
     if (this.lockAcquireFailures >= 3) {
-      this.logger.error(
+      this.testReporter.error(
         "Cache",
         "Failed to acquire lock 3 times in a row. Releasing lock manually.",
       );
@@ -196,7 +196,7 @@ export class BaseCache<T extends CacheEntry> {
       }
       this.lockAcquired = false;
     } catch {
-      this.logger.error("Cache", "Failed to release lock");
+      this.testReporter.error("Cache", "Failed to release lock");
     }
   }
 
@@ -210,7 +210,7 @@ export class BaseCache<T extends CacheEntry> {
     process.on("SIGINT", releaseLockAndExit);
     process.on("SIGTERM", releaseLockAndExit);
     process.on("uncaughtException", (err) => {
-      this.logger.error("Cache", err.message);
+      this.testReporter.error("Cache", err.message);
       if (this.lockAcquired) {
         releaseLockAndExit();
       }

--- a/packages/shortest/src/cache/cache.ts
+++ b/packages/shortest/src/cache/cache.ts
@@ -49,7 +49,10 @@ export class BaseCache<T extends CacheEntry> {
 
   public async get(key: Record<any, any>): Promise<T | null> {
     if (!(await this.acquireLock())) {
-      this.testReporter.error("Cache", "Failed to acquire lock for set operation");
+      this.testReporter.error(
+        "Cache",
+        "Failed to acquire lock for set operation",
+      );
       return null;
     }
     try {
@@ -69,7 +72,10 @@ export class BaseCache<T extends CacheEntry> {
     value: Partial<T["data"]>,
   ): Promise<void> {
     if (!(await this.acquireLock())) {
-      this.testReporter.error("Cache", "Failed to acquire lock for set operation");
+      this.testReporter.error(
+        "Cache",
+        "Failed to acquire lock for set operation",
+      );
       return;
     }
     try {
@@ -117,7 +123,10 @@ export class BaseCache<T extends CacheEntry> {
 
   public async delete(key: Record<string, any>): Promise<void> {
     if (!(await this.acquireLock())) {
-      this.testReporter.error("Cache", "Failed to acquire lock for delete operation");
+      this.testReporter.error(
+        "Cache",
+        "Failed to acquire lock for delete operation",
+      );
       return;
     }
 

--- a/packages/shortest/src/core/runner/test-reporter.ts
+++ b/packages/shortest/src/core/runner/test-reporter.ts
@@ -1,5 +1,5 @@
 import pc from "picocolors";
-import { AssertionError, TestFunction } from "../types";
+import { AssertionError, TestFunction } from "../../types";
 
 export type TestStatus = "pending" | "running" | "passed" | "failed";
 
@@ -15,7 +15,7 @@ interface TestResult {
   tokenUsage?: TokenMetrics;
 }
 
-export class Logger {
+export class TestReporter {
   private currentFile: string = "";
   private testResults: Record<string, TestResult> = {};
   private startTime: number = Date.now();


### PR DESCRIPTION
`TestReporter` (formerly `Logger`) is actually **aggregating test results** (passed/failed, token usage, summary stats, etc), rather than writing logs.
Extracted from a WIP PR that will introduce `Log`, a lower-level logging system that will handle text output, color-coding, grouping, etc. 