### PR TITLE
fix: expose runner errors

### DIFF
--- a/packages/shortest/package.json
+++ b/packages/shortest/package.json
@@ -23,6 +23,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && pnpm build:types && pnpm build:js && pnpm build:cli",
+    "build:pack": "pnpm build && pnpm pack",
     "prepare": "pnpm build",
     "prepublishOnly": "pnpm build",
     "postinstall": "node -e \"if (process.platform !== 'win32') { try { require('child_process').execSync('chmod +x dist/cli/bin.js') } catch (_) {} }\"",

--- a/packages/shortest/src/cli/bin.ts
+++ b/packages/shortest/src/cli/bin.ts
@@ -157,7 +157,7 @@ async function main() {
     .filter((arg) => !isValidArg(arg));
 
   if (invalidFlags.length > 0) {
-    log.error("Invalid argument(s)", { invalidFlags });
+    console.error("Invalid argument(s)", { invalidFlags });
     process.exit(1);
   }
 
@@ -182,7 +182,7 @@ async function main() {
     const testPattern = cliTestPattern || config.testPattern;
     await runner.runTests(testPattern);
   } catch (error: any) {
-    log.error(pc.red(error.name), { message: error.message });
+    console.error(pc.red(error.name), { message: error.message });
     process.exit(1);
   }
 }

--- a/packages/shortest/src/utils/config.ts
+++ b/packages/shortest/src/utils/config.ts
@@ -1,11 +1,15 @@
 import { z, ZodError } from "zod";
+import { getLogger } from "@/log/index";
 import { configSchema, ShortestConfig } from "@/types/config";
 import { ConfigError } from "@/utils/errors";
 
 export const parseConfig = (config: unknown): ShortestConfig => {
+  const log = getLogger();
+  log.trace("Parsing config", { config });
   try {
     return configSchema.parse(config);
   } catch (error) {
+    log.error("Error parsing config", { error });
     if (error instanceof z.ZodError) {
       throw new ConfigError("invalid-config", formatZodError(error));
     }


### PR DESCRIPTION
Before this change, any errors were supressed from being rendered because the main logger uses `—-log-level=silent` by default.

![CleanShot 2025-02-11 at 15 06 21@2x](https://github.com/user-attachments/assets/7dd48c3c-854f-4cd1-8dd6-d758f814b2db)
