### PR TITLE
feat(eslint): enforce Zod schema types

### DIFF
--- a/app/(dashboard)/dashboard/types.ts
+++ b/app/(dashboard)/dashboard/types.ts
@@ -21,6 +21,7 @@ export interface TestFile {
   oldContent?: string;
 }
 
+// eslint-disable-next-line zod/require-zod-schema-types
 export type CommitChangesToPullRequest = (
   owner: string,
   repo: string,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import eslintPluginImport from "eslint-plugin-import";
 import eslintPluginPrettier from "eslint-plugin-prettier";
 import typescriptEslintPlugin from "@typescript-eslint/eslint-plugin";
 import typescriptEslintParser from "@typescript-eslint/parser";
+import requireZodSchemaTypes from "./eslint/require-zod-schema-types.js";
 
 export default [
   {
@@ -24,6 +25,7 @@ export default [
         },
         ecmaVersion: "latest",
         sourceType: "module",
+        project: ["./tsconfig.json", "./packages/shortest/tsconfig.json"],
       },
     },
     plugins: {
@@ -31,6 +33,11 @@ export default [
       react: eslintPluginReact,
       import: eslintPluginImport,
       prettier: eslintPluginPrettier,
+      "zod": {
+        rules: {
+          "require-zod-schema-types": requireZodSchemaTypes,
+        },
+      },
     },
     rules: {
       "react/react-in-jsx-scope": "off",
@@ -38,14 +45,12 @@ export default [
         "error",
         { argsIgnorePattern: "^_" },
       ],
-      "func-style": ["error", "expression", {
-        "allowArrowFunctions": true
-      }],
+      "func-style": ["error", "expression", { allowArrowFunctions: true }],
       "arrow-body-style": ["error", "as-needed"],
       "eqeqeq": ["error", "smart"],
       "no-lonely-if": "error",
       "no-lone-blocks": "error",
-      "no-empty": ["error", { "allowEmptyCatch": true }],
+      "no-empty": ["error", { allowEmptyCatch: true }],
       "no-else-return": "error",
       "no-alert": "error",
       "logical-assignment-operators": "error",
@@ -57,6 +62,7 @@ export default [
           trailingComma: "all",
         },
       ],
+      "zod/require-zod-schema-types": "error",
     },
     settings: {
       react: {

--- a/eslint/require-zod-schema-types.js
+++ b/eslint/require-zod-schema-types.js
@@ -34,27 +34,27 @@ export default {
      * //   }
      * // }
      */
-    const DEBUG_TYPES = process.env.ZOD_SCHEMA_TYPES_DEBUG === 'true';
+    const DEBUG_TYPES = process.env.ZOD_SCHEMA_TYPES_DEBUG === "true";
 
     /** Debug helper for analyzing type patterns */
-    const debugTypePattern = (node, name = '') => {
+    const debugTypePattern = (node, name = "") => {
       if (!DEBUG_TYPES) return;
 
-      const filename = context.getFilename();
+      const filename = context.filename;
       const location = node.loc?.start;
       const locationStr = location ? `${filename}:${location.line}:${location.column}` : filename;
 
       // Get the core structure we care about
       const structure = {
         nodeType: node.type,
-        ...(node.type === 'TSTypeQuery' && {
+        ...(node.type === "TSTypeQuery" && {
           expression: {
             type: node.exprName?.type,
             table: node.exprName?.left?.name,
             method: node.exprName?.right?.name
           }
         }),
-        ...(node.type === 'TSTypeReference' && {
+        ...(node.type === "TSTypeReference" && {
           typeName: {
             type: node.typeName?.type,
             namespace: node.typeName?.left?.name,

--- a/eslint/require-zod-schema-types.js
+++ b/eslint/require-zod-schema-types.js
@@ -44,7 +44,6 @@ export default {
       const location = node.loc?.start;
       const locationStr = location ? `${filename}:${location.line}:${location.column}` : filename;
 
-      // Get the core structure we care about
       const structure = {
         nodeType: node.type,
         ...(node.type === "TSTypeQuery" && {
@@ -110,12 +109,10 @@ export default {
     const isZodReference = (typeName) => {
       const { left } = typeName;
 
-      // Check direct z.infer
       if (left.type === "Identifier") {
         return zodIdentifiers.has(left.name);
       }
 
-      // Check namespace.z.infer
       if (
         left.type === "TSQualifiedName" &&
         left.left.type === "Identifier"

--- a/eslint/require-zod-schema-types.js
+++ b/eslint/require-zod-schema-types.js
@@ -1,0 +1,173 @@
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Require type aliases to be derived from Zod schemas for runtime type validation. React component types and Drizzle ORM types are exempt. @see https://zod.dev",
+    },
+    schema: [],
+    messages: {
+      useInfer: "Type aliases must use z.infer<typeof Schema> for runtime validation. Example:\n" +
+        "const MySchema = z.object({ field: z.string() });\n" +
+        "type MyType = z.infer<typeof MySchema>;\n\n" +
+        "See https://zod.dev for more examples."
+    },
+  },
+  create(context) {
+    const zodIdentifiers = new Set();
+
+    /**
+     * Set ZOD_SCHEMA_TYPES_DEBUG=true in environment to debug all type patterns.
+     * Example: ZOD_SCHEMA_TYPES_DEBUG=true npx eslint .
+     *
+     * Useful when adding support for new type structures.
+     * @example
+     * // Example output:
+     * // /path/to/file.ts:42:10
+     * // Type: User
+     * // Structure: {
+     * //   "nodeType": "TSTypeQuery",
+     * //   "expression": {
+     * //     "type": "TSQualifiedName",
+     * //     "table": "users",
+     * //     "method": "$inferSelect"
+     * //   }
+     * // }
+     */
+    const DEBUG_TYPES = process.env.ZOD_SCHEMA_TYPES_DEBUG === 'true';
+
+    /** Debug helper for analyzing type patterns */
+    const debugTypePattern = (node, name = '') => {
+      if (!DEBUG_TYPES) return;
+
+      const filename = context.getFilename();
+      const location = node.loc?.start;
+      const locationStr = location ? `${filename}:${location.line}:${location.column}` : filename;
+
+      // Get the core structure we care about
+      const structure = {
+        nodeType: node.type,
+        ...(node.type === 'TSTypeQuery' && {
+          expression: {
+            type: node.exprName?.type,
+            table: node.exprName?.left?.name,
+            method: node.exprName?.right?.name
+          }
+        }),
+        ...(node.type === 'TSTypeReference' && {
+          typeName: {
+            type: node.typeName?.type,
+            namespace: node.typeName?.left?.name,
+            method: node.typeName?.right?.name
+          }
+        })
+      };
+
+      console.log(
+        `\n${locationStr}\n` +
+        `Type: ${name}\n` +
+        `Structure: ${JSON.stringify(structure, null, 2)}`
+      );
+    };
+
+    /** @param {import('@typescript-eslint/types').TSESTree.ImportClause} specifier */
+    const isZodImport = (specifier) => {
+      if (specifier.type !== "ImportSpecifier") return false;
+      return (
+        specifier.imported.type === "Identifier" &&
+        specifier.imported.name === "z"
+      );
+    };
+
+    /** @param {import('@typescript-eslint/types').TSESTree.TypeNode} typeAnnotation */
+    const isReactType = (typeAnnotation) => {
+      if (
+        !typeAnnotation?.typeName ||
+        typeAnnotation.typeName.type !== "TSQualifiedName"
+      ) {
+        return false;
+      }
+
+      const { left } = typeAnnotation.typeName;
+      return left.type === "Identifier" && left.name === "React";
+    };
+
+    /** @param {import('@typescript-eslint/types').TSESTree.TypeNode} typeAnnotation */
+    const isDrizzleInferType = (typeAnnotation) => {
+      if (typeAnnotation?.type !== "TSTypeQuery") return false;
+
+      const { exprName } = typeAnnotation;
+      if (!exprName || exprName.type !== "TSQualifiedName") return false;
+
+      const { right } = exprName;
+      return (
+        right?.type === "Identifier" &&
+        (right.name === "$inferSelect" || right.name === "$inferInsert")
+      );
+    };
+
+    /** @param {import('@typescript-eslint/types').TSESTree.TSQualifiedName} typeName */
+    const isZodReference = (typeName) => {
+      const { left } = typeName;
+
+      // Check direct z.infer
+      if (left.type === "Identifier") {
+        return zodIdentifiers.has(left.name);
+      }
+
+      // Check namespace.z.infer
+      if (
+        left.type === "TSQualifiedName" &&
+        left.left.type === "Identifier"
+      ) {
+        return zodIdentifiers.has(left.left.name);
+      }
+
+      return false;
+    };
+
+    /** @param {import('@typescript-eslint/types').TSESTree.TypeNode} typeAnnotation */
+    const isZodInferType = (typeAnnotation) => {
+      if (
+        !typeAnnotation?.typeName ||
+        typeAnnotation.typeName.type !== "TSQualifiedName"
+      ) {
+        return false;
+      }
+
+      const { right } = typeAnnotation.typeName;
+      return (
+        isZodReference(typeAnnotation.typeName) &&
+        right.type === "Identifier" &&
+        right.name === "infer"
+      );
+    };
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === "zod") {
+          node.specifiers
+            .filter(isZodImport)
+            .forEach((spec) => zodIdentifiers.add(spec.local.name));
+        }
+      },
+
+      TSTypeAliasDeclaration(node) {
+        debugTypePattern(node.typeAnnotation, node.id.name);
+
+        if (
+          isReactType(node.typeAnnotation) ||
+          isDrizzleInferType(node.typeAnnotation) ||
+          isZodInferType(node.typeAnnotation)
+        ) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: "useInfer",
+        });
+      },
+    };
+  },
+};

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -8,6 +8,7 @@ import type { ToastActionElement, ToastProps } from "@/components/ui/toast";
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000000;
 
+// eslint-disable-next-line zod/require-zod-schema-types
 type ToasterToast = ToastProps & {
   id: string;
   title?: React.ReactNode;
@@ -15,6 +16,7 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement;
 };
 
+// eslint-disable-next-line zod/require-zod-schema-types
 type ActionTypes = {
   ADD_TOAST: "ADD_TOAST";
   UPDATE_TOAST: "UPDATE_TOAST";
@@ -29,6 +31,7 @@ const genId = () => {
   return count.toString();
 };
 
+// eslint-disable-next-line zod/require-zod-schema-types
 type Action =
   | {
       type: ActionTypes["ADD_TOAST"];
@@ -135,6 +138,7 @@ const dispatch = (action: Action) => {
   });
 };
 
+// eslint-disable-next-line zod/require-zod-schema-types
 type Toast = Omit<ToasterToast, "id">;
 
 const toast = ({ ...props }: Toast) => {

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -49,7 +49,6 @@ export const pullRequests = pgTable(
     ),
   }),
 );
-
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type PullRequest = typeof pullRequests.$inferSelect;

--- a/packages/shortest/src/ai/client.ts
+++ b/packages/shortest/src/ai/client.ts
@@ -40,6 +40,8 @@ import { sleep } from "@/utils/sleep";
  *
  * @private
  */
+
+// eslint-disable-next-line zod/require-zod-schema-types
 export type AIClientResponse = {
   response: AIJSONResponse;
   metadata: {

--- a/packages/shortest/src/browser/core/bash-tool.ts
+++ b/packages/shortest/src/browser/core/bash-tool.ts
@@ -1,6 +1,7 @@
 import { spawn } from "child_process";
 import { getLogger, Log } from "@/log";
 
+// eslint-disable-next-line zod/require-zod-schema-types
 type BashToolError = "timeout" | "network" | "unknown" | "unauthorized";
 
 export class BashTool {

--- a/packages/shortest/src/core/runner/index.ts
+++ b/packages/shortest/src/core/runner/index.ts
@@ -24,6 +24,7 @@ import { hashData } from "@/utils/crypto";
 import { getErrorDetails } from "@/utils/errors";
 
 const STATUSES = ["pending", "running", "passed", "failed"] as const;
+// eslint-disable-next-line zod/require-zod-schema-types
 export type TestStatus = (typeof STATUSES)[number];
 
 export const TestResultSchema = z.object({

--- a/packages/shortest/src/log/config.ts
+++ b/packages/shortest/src/log/config.ts
@@ -23,9 +23,11 @@ export const LOG_LEVELS = [
   "error",
   "silent",
 ] as const;
+// eslint-disable-next-line zod/require-zod-schema-types
 export type LogLevel = (typeof LOG_LEVELS)[number];
 
 export const LOG_FORMATS = ["terminal", "pretty", "reporter"] as const;
+// eslint-disable-next-line zod/require-zod-schema-types
 export type LogFormat = (typeof LOG_FORMATS)[number];
 
 export const LogConfigSchema = z.object({

--- a/packages/shortest/src/types/browser.ts
+++ b/packages/shortest/src/types/browser.ts
@@ -32,6 +32,7 @@ export enum BrowserActionEnum {
   CheckMail = "check_email",
 }
 
+// eslint-disable-next-line zod/require-zod-schema-types
 export type BrowserAction = `${BrowserActionEnum}`;
 
 export interface BrowserToolOptions {
@@ -83,6 +84,7 @@ export interface BrowserToolConfig {
   testContext?: TestContext;
 }
 
+// eslint-disable-next-line zod/require-zod-schema-types
 export type BetaToolType =
   | "computer_20241022"
   | "text_editor_20241022"

--- a/packages/shortest/src/types/test.ts
+++ b/packages/shortest/src/types/test.ts
@@ -28,6 +28,7 @@ export class AssertionCallbackError extends CallbackError {
   }
 }
 
+// eslint-disable-next-line zod/require-zod-schema-types
 export type TestContext = {
   page: Page;
   browser: Browser;
@@ -42,6 +43,7 @@ export type TestContext = {
   currentStepIndex?: number;
 };
 
+// eslint-disable-next-line zod/require-zod-schema-types
 export type TestHookFunction = (context: TestContext) => Promise<void>;
 
 export interface TestFunction {
@@ -60,6 +62,7 @@ export interface TestFunction {
   directExecution?: boolean;
 }
 
+// eslint-disable-next-line zod/require-zod-schema-types
 export type TestChain = {
   expect(fn: (context: TestContext) => Promise<void>): TestChain;
   expect(description: string): TestChain;
@@ -76,6 +79,7 @@ export type TestChain = {
   after(fn: (context: TestContext) => void | Promise<void>): TestChain;
 };
 
+// eslint-disable-next-line zod/require-zod-schema-types
 export type TestAPI = {
   (fn: (context: TestContext) => Promise<void>): TestChain;
   (name: string): TestChain;
@@ -100,6 +104,7 @@ export type TestAPI = {
   afterEach(name: string, fn: (context: TestContext) => Promise<void>): void;
 };
 
+// eslint-disable-next-line zod/require-zod-schema-types
 export type TestRegistry = {
   tests: Map<string, TestFunction[]>;
   currentFileTests: TestFunction[];

--- a/packages/shortest/src/utils/add-to-env.ts
+++ b/packages/shortest/src/utils/add-to-env.ts
@@ -3,6 +3,7 @@ import os from "os";
 import { join } from "path";
 import { ENV_LOCAL_FILENAME } from "@/constants";
 
+// eslint-disable-next-line zod/require-zod-schema-types
 type EnvResult = {
   added: string[];
   skipped: string[];

--- a/packages/shortest/src/utils/add-to-gitignore.ts
+++ b/packages/shortest/src/utils/add-to-gitignore.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import os from "os";
 import { join } from "path";
 
+// eslint-disable-next-line zod/require-zod-schema-types
 type GitIgnoreResult = {
   wasCreated: boolean;
   wasUpdated: boolean;

--- a/packages/shortest/src/utils/errors.ts
+++ b/packages/shortest/src/utils/errors.ts
@@ -1,5 +1,6 @@
 import { ZodError } from "zod";
 
+// eslint-disable-next-line zod/require-zod-schema-types
 export type ConfigErrorType =
   | "duplicate-config"
   | "file-not-found"
@@ -15,6 +16,7 @@ export class ConfigError extends Error {
   }
 }
 
+// eslint-disable-next-line zod/require-zod-schema-types
 export type AIErrorType =
   | "invalid-response"
   | "max-retries-reached"

--- a/packages/shortest/tsconfig.json
+++ b/packages/shortest/tsconfig.json
@@ -15,6 +15,6 @@
       },
       "types": ["node", "jest"]
     },
-    "include": ["src/**/*", "tests/**/*"],
+    "include": ["src/**/*", "tests/**/*", "vitest.config.ts"],
     "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Add a custom ESLint rule that enforces using Zod schemas for runtime type validation.

## What
- Add `require-zod-schema-types` ESLint rule
- Configure rule to exempt React and Drizzle ORM types
- Add `eslint-disable` comments for existing type-only definitions
- Include vitest.config.ts in TypeScript project

## Why
- Ensures consistent runtime type validation by requiring Zod schemas
- Enforces new code moving forward uses Zod schema
- Prevents type-only types that lack runtime validation

## Future work
- Convert existing type-only definitions to Zod schemas
- Extend rule to enforce Zod over interfaces