### PR TITLE
feat(cli): merge CLI options into config

### DIFF
--- a/packages/shortest/src/browser/core/browser-tool.ts
+++ b/packages/shortest/src/browser/core/browser-tool.ts
@@ -74,7 +74,7 @@ export class BrowserTool extends BaseBrowserTool {
   }
 
   private async initialize(): Promise<void> {
-    await initializeConfig();
+    await initializeConfig({});
     this.config = getConfig();
 
     const initWithRetry = async () => {

--- a/packages/shortest/src/cli/bin.ts
+++ b/packages/shortest/src/cli/bin.ts
@@ -3,9 +3,10 @@ import pc from "picocolors";
 import { GitHubTool } from "@/browser/integrations/github";
 import { ENV_LOCAL_FILENAME } from "@/constants";
 import { TestRunner } from "@/core/runner";
-import { getConfig } from "@/index";
+import { getConfig, initializeConfig } from "@/index";
 import { LogLevel } from "@/log/config";
 import { getLogger } from "@/log/index";
+import { CLIOptions } from "@/types";
 
 process.removeAllListeners("warning");
 process.on("warning", (warning) => {
@@ -163,24 +164,28 @@ const main = async () => {
   }
 
   const headless = args.includes("--headless");
-  const targetUrl = args
+  const baseUrl = args
     .find((arg) => arg.startsWith("--target="))
     ?.split("=")[1];
-  const cliTestPattern = args.find((arg) => !arg.startsWith("--"));
+  const testPattern = args.find((arg) => !arg.startsWith("--"));
   const noCache = args.includes("--no-cache");
+
+  const cliOptions: CLIOptions = {
+    headless,
+    baseUrl,
+    testPattern,
+    noCache,
+  };
+  log.trace("Initializing config with CLI options", { cliOptions });
+  await initializeConfig({ cliOptions });
+  const config = getConfig();
 
   log.trace("Initializing TestRunner");
   try {
-    const runner = new TestRunner(
-      process.cwd(),
-      true,
-      headless,
-      targetUrl,
-      noCache,
-    );
+    const runner = new TestRunner(process.cwd(), config);
     await runner.initialize();
-    const config = getConfig();
-    const testPattern = cliTestPattern || config.testPattern;
+    // const config = getConfig();
+    // const testPattern = cliTestPattern || config.testPattern;
     await runner.runTests(testPattern);
   } catch (error: any) {
     console.error(pc.red(error.name), error.message);

--- a/packages/shortest/src/cli/bin.ts
+++ b/packages/shortest/src/cli/bin.ts
@@ -184,8 +184,6 @@ const main = async () => {
   try {
     const runner = new TestRunner(process.cwd(), config);
     await runner.initialize();
-    // const config = getConfig();
-    // const testPattern = cliTestPattern || config.testPattern;
     await runner.runTests(testPattern);
   } catch (error: any) {
     console.error(pc.red(error.name), error.message);

--- a/packages/shortest/src/index.ts
+++ b/packages/shortest/src/index.ts
@@ -11,6 +11,7 @@ import {
   TestContext,
   TestChain,
   ShortestStrictConfig,
+  CLIOptions,
 } from "@/types";
 import { parseConfig } from "@/utils/config";
 import { ConfigError } from "@/utils/errors";
@@ -47,14 +48,19 @@ if (!global.__shortest__) {
   dotenv.config({ path: join(process.cwd(), ENV_LOCAL_FILENAME) });
 }
 
-export const initializeConfig = async (configDir?: string) => {
+export const initializeConfig = async ({
+  cliOptions,
+  configDir = process.cwd(),
+}: {
+  cliOptions?: CLIOptions;
+  configDir?: string;
+}) => {
   const log = getLogger();
   if (globalConfig) {
     return globalConfig;
   }
   log.trace("Initializing config");
 
-  configDir ||= process.cwd();
   dotenv.config({ path: join(configDir, ".env") });
   dotenv.config({ path: join(configDir, ENV_LOCAL_FILENAME) });
 
@@ -70,7 +76,7 @@ export const initializeConfig = async (configDir?: string) => {
       const module = await compiler.loadModule(file, configDir);
 
       const userConfig = module.default;
-      const parsedConfig = parseConfig(userConfig);
+      const parsedConfig = parseConfig(userConfig, cliOptions);
       configs.push({
         file,
         config: parsedConfig,

--- a/packages/shortest/src/types/config.ts
+++ b/packages/shortest/src/types/config.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
 
-const mailosaurSchema = z
-  .object({
-    apiKey: z.string(),
-    serverId: z.string(),
-  })
-  .optional();
+export const cliOptionsSchema = z.object({
+  headless: z.boolean().optional(),
+  baseUrl: z.string().optional(),
+  testPattern: z.string().optional(),
+  noCache: z.boolean().optional(),
+});
+export type CLIOptions = z.infer<typeof cliOptionsSchema>;
 
 const ANTHROPIC_MODELS = ["claude-3-5-sonnet-20241022"] as const;
 
@@ -24,6 +25,20 @@ const aiSchema = z
   .strict();
 export type AIConfig = z.infer<typeof aiSchema>;
 
+const cachingSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+  })
+  .strict();
+export type CachingConfig = z.infer<typeof cachingSchema>;
+
+const mailosaurSchema = z
+  .object({
+    apiKey: z.string(),
+    serverId: z.string(),
+  })
+  .optional();
+
 export const configSchema = z
   .object({
     headless: z.boolean().default(true),
@@ -32,14 +47,16 @@ export const configSchema = z
     anthropicKey: z.string().optional(),
     ai: aiSchema,
     mailosaur: mailosaurSchema.optional(),
+    caching: cachingSchema.optional().default(cachingSchema.parse({})),
   })
   .strict();
 
 export const userConfigSchema = configSchema.extend({
   ai: aiSchema.strict().partial().optional(),
+  caching: cachingSchema.strict().partial().optional(),
 });
 
-const SHORTEST_ENV_PREFIX = "SHORTTEST_";
+const SHORTEST_ENV_PREFIX = "SHORTEST_";
 
 const getShortestEnvName = (key: string) => `${SHORTEST_ENV_PREFIX}${key}`;
 

--- a/packages/shortest/tests/e2e/index.ts
+++ b/packages/shortest/tests/e2e/index.ts
@@ -54,7 +54,7 @@ describe("End-to-end tests", async () => {
     try {
       console.log(pc.cyan("\n🚀 Initializing test environment..."));
       console.log(pc.cyan(`Looking for config in: ${projectRoot}`));
-      await initializeConfig(projectRoot);
+      await initializeConfig({ configDir: projectRoot });
       isSetupComplete = true;
     } catch (error) {
       console.error(pc.red("\n❌ Failed to initialize config:"), error);

--- a/packages/shortest/tests/e2e/test-ai.ts
+++ b/packages/shortest/tests/e2e/test-ai.ts
@@ -13,7 +13,7 @@ export const main = async () => {
   const browserManager = new BrowserManager(getConfig());
 
   try {
-    await initializeConfig();
+    await initializeConfig({});
     console.log("🚀 Launching browser...");
     const context = await browserManager.launch();
     const page = context.pages()[0];

--- a/packages/shortest/tests/e2e/test-email-rendering.ts
+++ b/packages/shortest/tests/e2e/test-email-rendering.ts
@@ -8,7 +8,7 @@ import { getConfig, initializeConfig } from "@/index";
 export const main = async () => {
   console.log(pc.cyan("\n📧 Testing Email"));
 
-  await initializeConfig();
+  await initializeConfig({});
   const config = getConfig();
 
   if (!config.mailosaur?.apiKey || !config.mailosaur?.serverId) {

--- a/packages/shortest/tests/e2e/test-github-login.ts
+++ b/packages/shortest/tests/e2e/test-github-login.ts
@@ -9,7 +9,7 @@ export const main = async () => {
   const githubTool = new GitHubTool();
 
   try {
-    await initializeConfig();
+    await initializeConfig({});
     console.log(pc.cyan("\n🚀 First browser launch..."));
     let context = await browserManager.launch();
     let page = context.pages()[0];

--- a/packages/shortest/tests/e2e/test-keyboard.ts
+++ b/packages/shortest/tests/e2e/test-keyboard.ts
@@ -7,7 +7,7 @@ export const main = async () => {
   const browserManager = new BrowserManager(getConfig());
 
   try {
-    await initializeConfig();
+    await initializeConfig({});
     console.log(pc.cyan("\n🚀 Launching browser..."));
     const context = await browserManager.launch();
     const page = context.pages()[0];

--- a/packages/shortest/tests/unit/config.test.ts
+++ b/packages/shortest/tests/unit/config.test.ts
@@ -19,6 +19,41 @@ describe("Config parsing", () => {
     };
   });
 
+  describe("with zero config", () => {
+    // process.env.ANTHROPIC_API_KEY = "env-api-key";
+    const zeroConfig = {
+      baseUrl: "https://example.com",
+      testPattern: ".*",
+      ai: {
+        provider: "anthropic",
+        apiKey: "foo",
+      },
+    } as ShortestConfig;
+
+    test("it generates default config", () => {
+      const config = parseConfig(zeroConfig);
+      console.log(config);
+      expect(Object.keys(config)).toEqual([
+        "headless",
+        "baseUrl",
+        "testPattern",
+        "ai",
+        "caching",
+      ]);
+      expect(config.headless).toBe(true);
+      expect(config.baseUrl).toBe("https://example.com");
+      expect(config.testPattern).toBe(".*");
+      expect(config.ai).toEqual({
+        apiKey: "foo",
+        model: "claude-3-5-sonnet-20241022",
+        provider: "anthropic",
+      });
+      expect(config.caching).toEqual({
+        enabled: true,
+      });
+    });
+  });
+
   describe("with invalid config option", () => {
     test("it throws an error", () => {
       const userConfig = {
@@ -40,7 +75,6 @@ describe("Config parsing", () => {
           invalidAIOption: "value",
         },
       };
-      console.log(userConfig);
       expect(() => parseConfig(userConfig)).toThrowError(
         "Unrecognized key(s) in object: 'invalidAIOption'",
       );
@@ -86,12 +120,12 @@ describe("Config parsing", () => {
         });
       });
 
-      describe("with SHORTTEST_ANTHROPIC_API_KEY", () => {
+      describe("with SHORTEST_ANTHROPIC_API_KEY", () => {
         beforeEach(() => {
-          process.env.SHORTTEST_ANTHROPIC_API_KEY = "shortest-env-api-key";
+          process.env.SHORTEST_ANTHROPIC_API_KEY = "shortest-env-api-key";
         });
 
-        test("uses value from SHORTTEST_ANTHROPIC_API_KEY", () => {
+        test("uses value from SHORTEST_ANTHROPIC_API_KEY", () => {
           const userConfig = {
             ...baseConfig,
             ai: {

--- a/packages/shortest/tests/unit/config.test.ts
+++ b/packages/shortest/tests/unit/config.test.ts
@@ -19,9 +19,8 @@ describe("Config parsing", () => {
     };
   });
 
-  describe("with zero config", () => {
-    // process.env.ANTHROPIC_API_KEY = "env-api-key";
-    const zeroConfig = {
+  describe("with minimal config", () => {
+    const minimalConfig = {
       baseUrl: "https://example.com",
       testPattern: ".*",
       ai: {
@@ -31,7 +30,7 @@ describe("Config parsing", () => {
     } as ShortestConfig;
 
     test("it generates default config", () => {
-      const config = parseConfig(zeroConfig);
+      const config = parseConfig(minimalConfig);
       console.log(config);
       expect(Object.keys(config)).toEqual([
         "headless",


### PR DESCRIPTION
Simplify usage of CLI arguments by merging them into the user config schema, which is then properly validated

### Why

* Part of issue #287 
* It simplifies the logic working with CLI arguments.
* Leverages Zod's validation as the source of truth of all the config values passed by the user, regardless if are coming via the CLI, or the config file