### PR TITLE
feat: make config.testPattern optional

### DIFF
--- a/packages/shortest/src/cli/bin.ts
+++ b/packages/shortest/src/cli/bin.ts
@@ -40,48 +40,37 @@ ${pc.bold("Shortest")} - AI-powered end-to-end testing framework
 ${pc.dim("https://github.com/anti-work/shortest")}
 
 ${pc.bold("Usage:")}
-  shortest [options] [test-pattern]
-  shortest cache clear [--force-purge]
-
-${pc.bold("Commands:")}
-  init                  Initialize Shortest in the current directory
-  cache clear           Clear test cache
-    --force-purge       Force delete all cache files
+  $ shortest [options] [pattern]                  Run tests matching pattern (default: **/*.test.ts)
+  $ shortest init                                 Initialize Shortest in current directory
+  $ shortest cache clear [--force-purge]          Clear test cache
 
 ${pc.bold("Options:")}
-  --headless            Run tests in headless browser mode
-  --log-level=<level>   Set log level (default: silent). Options: silent, error, warn, info, debug, trace
-  --target=<url>        Set target URL for tests (default: http://localhost:3000)
-  --github-code         Generate GitHub 2FA code for authentication
-  --no-cache            Disable caching (storing browser actions between tests)
+  --headless                                      Run tests in headless browser mode
+  --target=<url>                                  Set target URL for tests (default: http://localhost:3000)
+  --no-cache                                      Disable test action caching
+  --log-level=<level>                             Set logging level [silent|error|warn|info|debug|trace] (default: silent)
+  --github-code                                   Generate GitHub 2FA code for authentication
+  --secret=<key>                                  GitHub TOTP secret key (can also be set in ${ENV_LOCAL_FILENAME})
 
-${pc.bold("Authentication:")}
-  --secret=<key>      GitHub TOTP secret key (or use ${ENV_LOCAL_FILENAME})
+${pc.bold("Environment setup:")}
+  Required in ${ENV_LOCAL_FILENAME}:
+    AI authentication
+      SHORTEST_ANTHROPIC_API_KEY                  Anthropic API key for AI test execution
+      ANTHROPIC_API_KEY                           Alternative Anthropic API key (only one is required)
+
+    GitHub authentication
+      GITHUB_TOTP_SECRET                          GitHub 2FA secret
+      GITHUB_USERNAME                             GitHub username
+      GITHUB_PASSWORD                             GitHub password
 
 ${pc.bold("Examples:")}
-  ${pc.dim("# Run all tests")}
-  shortest
-
-  ${pc.dim("# Run specific test file")}
-  shortest login.test.ts
-
-  ${pc.dim("# Run tests in headless mode")}
-  shortest --headless
-
-  ${pc.dim("# Generate GitHub 2FA code")}
-  shortest --github-code --secret=<OTP_SECRET>
-
-${pc.bold("Environment Setup:")}
-  Required variables in ${ENV_LOCAL_FILENAME}:
-  - ANTHROPIC_API_KEY     Required for AI test execution
-  - GITHUB_TOTP_SECRET    Required for GitHub authentication
-  - GITHUB_USERNAME       GitHub login credentials
-  - GITHUB_PASSWORD       GitHub login credentials
+  shortest                                        # Run all tests
+  shortest login.test.ts                          # Run a single test file
+  shortest --headless                             # Run in headless browser mode
+  shortest --github-code --secret=<OTP_SECRET>    # Generate GitHub 2FA code
 
 ${pc.bold("Documentation:")}
-  Visit ${pc.cyan(
-    "https://github.com/anti-work/shortest",
-  )} for detailed setup and usage
+  ${pc.cyan("https://github.com/anti-work/shortest")}
 `);
 };
 
@@ -205,7 +194,7 @@ const main = async () => {
     log.trace("Initializing TestRunner");
     const runner = new TestRunner(process.cwd(), config);
     await runner.initialize();
-    const success = await runner.runTests(testPattern);
+    const success = await runner.execute(config.testPattern);
     process.exitCode = success ? 0 : 1;
   } catch (error: any) {
     console.error(pc.red(error));

--- a/packages/shortest/src/types/config.ts
+++ b/packages/shortest/src/types/config.ts
@@ -39,11 +39,13 @@ const mailosaurSchema = z
   })
   .optional();
 
+const testPatternSchema = z.string().default("**/*.test.ts");
+
 export const configSchema = z
   .object({
     headless: z.boolean().default(true),
     baseUrl: z.string().url("must be a valid URL"),
-    testPattern: z.string(),
+    testPattern: testPatternSchema,
     anthropicKey: z.string().optional(),
     ai: aiSchema,
     mailosaur: mailosaurSchema.optional(),
@@ -52,6 +54,7 @@ export const configSchema = z
   .strict();
 
 export const userConfigSchema = configSchema.extend({
+  testPattern: testPatternSchema.optional(),
   ai: aiSchema.strict().partial().optional(),
   caching: cachingSchema.strict().partial().optional(),
 });

--- a/packages/shortest/src/utils/errors.ts
+++ b/packages/shortest/src/utils/errors.ts
@@ -35,6 +35,20 @@ export class AIError extends Error {
   }
 }
 
+class ShortestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ShortestError";
+  }
+}
+
+export class RunnerError extends ShortestError {
+  constructor(message: string) {
+    super(message);
+    this.name = "RunnerError";
+  }
+}
+
 export const getErrorDetails = (error: any) => ({
   message: error instanceof Error ? error.message : String(error),
   name: error instanceof Error ? error.name : "Unknown",

--- a/packages/shortest/src/utils/errors.ts
+++ b/packages/shortest/src/utils/errors.ts
@@ -35,20 +35,6 @@ export class AIError extends Error {
   }
 }
 
-class ShortestError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ShortestError";
-  }
-}
-
-export class RunnerError extends ShortestError {
-  constructor(message: string) {
-    super(message);
-    this.name = "RunnerError";
-  }
-}
-
 export const getErrorDetails = (error: any) => ({
   message: error instanceof Error ? error.message : String(error),
   name: error instanceof Error ? error.name : "Unknown",

--- a/packages/shortest/tests/unit/config.test.ts
+++ b/packages/shortest/tests/unit/config.test.ts
@@ -7,22 +7,9 @@ import { parseConfig } from "@/utils/config";
 describe("Config parsing", () => {
   let baseConfig: ShortestConfig;
 
-  beforeEach(() => {
-    baseConfig = {
-      headless: true,
-      baseUrl: "https://example.com",
-      testPattern: ".*",
-      ai: {
-        provider: "anthropic",
-        apiKey: "explicit-api-key",
-      },
-    };
-  });
-
   describe("with minimal config", () => {
     const minimalConfig = {
       baseUrl: "https://example.com",
-      testPattern: ".*",
       ai: {
         provider: "anthropic",
         apiKey: "foo",
@@ -40,7 +27,7 @@ describe("Config parsing", () => {
       ]);
       expect(config.headless).toBe(true);
       expect(config.baseUrl).toBe("https://example.com");
-      expect(config.testPattern).toBe(".*");
+      expect(config.testPattern).toBe("**/*.test.ts");
       expect(config.ai).toEqual({
         apiKey: "foo",
         model: "claude-3-5-sonnet-20241022",
@@ -50,6 +37,18 @@ describe("Config parsing", () => {
         enabled: true,
       });
     });
+  });
+
+  beforeEach(() => {
+    baseConfig = {
+      headless: true,
+      baseUrl: "https://example.com",
+      testPattern: ".*",
+      ai: {
+        provider: "anthropic",
+        apiKey: "explicit-api-key",
+      },
+    };
   });
 
   describe("with invalid config option", () => {

--- a/packages/shortest/tests/unit/initialize-config.test.ts
+++ b/packages/shortest/tests/unit/initialize-config.test.ts
@@ -54,13 +54,13 @@ describe("initializeConfig", () => {
       `
       export default {
         headless: true,
-        baseUrl: 'https://example.com',
-        testPattern: '.*',
+        baseUrl: "https://example.com",
+        testPattern: ".*",
         ai: {
           provider: "anthropic",
           apiKey: "test-key",
-          model: "claude-3-5-sonnet-20241022"
-        }
+          model: "claude-3-5-sonnet-20241022",
+        },
       }
       `,
     );
@@ -142,7 +142,7 @@ describe("initializeConfig", () => {
       );
     });
 
-    test("overwrite config options", async () => {
+    test("overwrites config options", async () => {
       const cliOptions = {
         headless: true,
         baseUrl: "https://other.example.com",


### PR DESCRIPTION
* Make `config.testPattern` optional, default to `**/*.test.ts`
* Improve test runner error handling
* Improve CLI help output formatting and organization

### Why

* One step closer towards zero-config
* Reduce complexity and technical debt around error handling and default values


![CleanShot 2025-02-22 at 16 26 13@2x](https://github.com/user-attachments/assets/2437aec7-84eb-4416-a8c5-91a0d5876003)
