### PR TITLE
fix: ES Module compatibility for dirname

### DIFF
--- a/packages/shortest/src/core/compiler/index.ts
+++ b/packages/shortest/src/core/compiler/index.ts
@@ -31,9 +31,10 @@ export class TestCompiler {
       js: `
         import { fileURLToPath } from 'url';
         import { dirname } from 'path';
+        import { createRequire } from 'module';
+
         const __filename = fileURLToPath(import.meta.url);
         const __dirname = dirname(__filename);
-        import { createRequire } from "module";
         const require = createRequire(import.meta.url);
       `,
     },
@@ -70,7 +71,15 @@ export class TestCompiler {
       },
       resolveExtensions: [".ts", ".js", ".mjs"],
       banner: {
-        js: 'import { createRequire } from "module";const require = createRequire(import.meta.url);',
+        js: `
+          import { fileURLToPath } from 'url';
+          import { dirname } from 'path';
+          import { createRequire } from 'module';
+
+          const __filename = fileURLToPath(import.meta.url);
+          const __dirname = dirname(__filename);
+          const require = createRequire(import.meta.url);
+        `,
       },
     });
 


### PR DESCRIPTION
Prevent "undefined in ES module scope" errors in type:module projects

Error when running Shortest on Flexile
![CleanShot 2025-02-25 at 12 25 24@2x](https://github.com/user-attachments/assets/bb5d5bdd-3517-4059-bcb1-9042730ab330)
