### PR TITLE
refactor: add ToolRegistry

### DIFF
--- a/packages/shortest/src/ai/client.ts
+++ b/packages/shortest/src/ai/client.ts
@@ -1,25 +1,22 @@
-import { anthropic } from "@ai-sdk/anthropic";
 import { LanguageModelV1FinishReason } from "@ai-sdk/provider";
 import {
   CoreMessage,
-  CoreTool,
+  Tool,
   generateText,
   LanguageModelV1,
   NoSuchToolError,
-  tool,
 } from "ai";
-import { z } from "zod";
 
 import { SYSTEM_PROMPT } from "@/ai/prompts";
 import { createProvider } from "@/ai/provider";
 import { AIJSONResponse, extractJsonPayload } from "@/ai/utils/json";
-import { BashTool } from "@/browser/core/bash-tool";
 import { BrowserTool } from "@/browser/core/browser-tool";
 import { TestCache } from "@/cache/test-cache";
 import { getConfig } from "@/index";
 import { getLogger, Log } from "@/log";
-import { ToolResult } from "@/types";
+import { createToolRegistry, ToolRegistry } from "@/tools/index";
 import { TokenUsage, TokenUsageSchema } from "@/types/ai";
+import { AIConfig } from "@/types/config";
 import {
   getErrorDetails,
   AIError,
@@ -87,8 +84,9 @@ export class AIClient {
   private log: Log;
   private usage: TokenUsage;
   private apiRequestCount: number = 0;
-  private _tools: Record<string, CoreTool> | null = null;
-
+  private toolRegistry: ToolRegistry;
+  private _tools: Record<string, Tool> | null = null;
+  private configAi: AIConfig;
   constructor({
     browserTool,
     testCache,
@@ -99,9 +97,11 @@ export class AIClient {
     this.log = getLogger();
     this.log.trace("Initializing AIClient");
     this.client = createProvider(getConfig().ai);
+    this.configAi = getConfig().ai;
     this.browserTool = browserTool;
     this.testCache = testCache;
     this.usage = TokenUsageSchema.parse({});
+    this.toolRegistry = createToolRegistry();
     this.log.trace(
       "Available tools",
       Object.fromEntries(
@@ -297,108 +297,17 @@ export class AIClient {
    *
    * @private
    */
-  private get tools(): Record<string, CoreTool> {
+  private get tools(): Record<string, Tool> {
     if (this._tools) return this._tools;
 
-    this._tools = {
-      computer: anthropic.tools.computer_20241022({
-        displayWidthPx: 1920,
-        displayHeightPx: 1080,
-        displayNumber: 0,
-        execute: this.browserTool.execute.bind(this.browserTool),
-        experimental_toToolResultContent:
-          this.browserToolResultToToolResultContent,
-      }),
-      bash: anthropic.tools.bash_20241022({
-        execute: async ({ command }) => await new BashTool().execute(command),
-        experimental_toToolResultContent(result) {
-          return [
-            {
-              type: "text",
-              text: result,
-            },
-          ];
-        },
-      }),
-      github_login: tool({
-        description: "Handle GitHub OAuth login with 2FA",
-        parameters: z.object({
-          action: z.literal("github_login"),
-          username: z.string(),
-          password: z.string(),
-        }),
-        execute: this.browserTool.execute.bind(this.browserTool),
-        experimental_toToolResultContent:
-          this.browserToolResultToToolResultContent,
-      }),
-      check_email: tool({
-        description: "View received email in new browser tab",
-        parameters: z.object({
-          action: z.literal("check_email"),
-          email: z.string().describe("Email content or address to check for"),
-        }),
-        execute: this.browserTool.execute.bind(this.browserTool),
-        experimental_toToolResultContent:
-          this.browserToolResultToToolResultContent,
-      }),
-      sleep: tool({
-        description: "Pause test execution for specified duration",
-        parameters: z.object({
-          action: z.literal("sleep"),
-          duration: z.number().min(0).max(60000),
-        }),
-        execute: this.browserTool.execute.bind(this.browserTool),
-        experimental_toToolResultContent:
-          this.browserToolResultToToolResultContent,
-      }),
-      run_callback: tool({
-        description: "Run callback function for current test step",
-        parameters: z.object({
-          action: z.literal("run_callback"),
-        }),
-        execute: this.browserTool.execute.bind(this.browserTool),
-        experimental_toToolResultContent:
-          this.browserToolResultToToolResultContent,
-      }),
-      navigate: tool({
-        description: "Navigate to URLs in new browser tabs",
-        parameters: z.object({
-          action: z.literal("navigate"),
-          url: z.string().url().describe("The URL to navigate to"),
-        }),
-        execute: this.browserTool.execute.bind(this.browserTool),
-        experimental_toToolResultContent:
-          this.browserToolResultToToolResultContent,
-      }),
-    };
+    this._tools = this.toolRegistry.getTools(
+      this.configAi.provider,
+      this.configAi.model,
+      this.browserTool,
+    );
+    // console.log("🐸🐸 tools", this._tools);
 
     return this._tools;
-  }
-
-  /**
-   * Converts browser tool execution results to standardized content format.
-   * Handles image data and text output formatting.
-   *
-   * @param {ToolResult} result - Raw tool execution result
-   * @returns {Array<{type: string, data?: string, text?: string, mimeType?: string}>} Formatted content
-   *
-   * @private
-   */
-  private browserToolResultToToolResultContent(result: ToolResult) {
-    return result.base64_image
-      ? [
-          {
-            type: "image" as const,
-            data: result.base64_image,
-            mimeType: "image/jpeg",
-          },
-        ]
-      : [
-          {
-            type: "text" as const,
-            text: result.output!,
-          },
-        ];
   }
 
   /**

--- a/packages/shortest/src/ai/client.ts
+++ b/packages/shortest/src/ai/client.ts
@@ -305,7 +305,6 @@ export class AIClient {
       this.configAi.model,
       this.browserTool,
     );
-    // console.log("🐸🐸 tools", this._tools);
 
     return this._tools;
   }

--- a/packages/shortest/src/ai/tools/anthropic/bash_20241022.ts
+++ b/packages/shortest/src/ai/tools/anthropic/bash_20241022.ts
@@ -1,0 +1,18 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { BashTool } from "@/browser/core/bash-tool";
+
+/**
+ * @see https://sdk.vercel.ai/providers/ai-sdk-providers/anthropic#bash-tool
+ */
+export const createAnthropicBash20241022 = () =>
+  anthropic.tools.bash_20241022({
+    execute: async ({ command }) => await new BashTool().execute(command),
+    experimental_toToolResultContent(result) {
+      return [
+        {
+          type: "text",
+          text: result,
+        },
+      ];
+    },
+  });

--- a/packages/shortest/src/ai/tools/anthropic/computer_20241022.ts
+++ b/packages/shortest/src/ai/tools/anthropic/computer_20241022.ts
@@ -1,0 +1,43 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { Tool } from "ai";
+import { BrowserTool } from "@/browser/core/browser-tool";
+import { InternalActionEnum } from "@/types/browser";
+
+/**
+ * @see https://sdk.vercel.ai/providers/ai-sdk-providers/anthropic#computer-tool
+ */
+export const createAnthropicComputer20241022 = (
+  browserTool: BrowserTool,
+): Tool =>
+  anthropic.tools.computer_20241022({
+    displayWidthPx: 1920,
+    displayHeightPx: 1080,
+    displayNumber: 0,
+    execute: async (input) => {
+      const { action, ...restOfInput } = input;
+      const internalAction = actionMap[action];
+      if (!internalAction) {
+        return { output: `Action '${action}' not supported` };
+      }
+      return browserTool.execute({ action: internalAction, ...restOfInput });
+    },
+    experimental_toToolResultContent: browserTool.resultToToolResultContent,
+  });
+
+/**
+ * Map of Anthropic computer_20241022 actions to internal actions
+ *
+ * @see https://docs.anthropic.com/en/docs/agents-and-tools/computer-use#computer-tool
+ */
+const actionMap: Record<string, InternalActionEnum> = {
+  key: InternalActionEnum.KEY,
+  type: InternalActionEnum.TYPE,
+  mouse_move: InternalActionEnum.MOUSE_MOVE,
+  left_click: InternalActionEnum.LEFT_CLICK,
+  left_click_drag: InternalActionEnum.LEFT_CLICK_DRAG,
+  right_click: InternalActionEnum.RIGHT_CLICK,
+  middle_click: InternalActionEnum.MIDDLE_CLICK,
+  double_click: InternalActionEnum.DOUBLE_CLICK,
+  screenshot: InternalActionEnum.SCREENSHOT,
+  cursor_position: InternalActionEnum.CURSOR_POSITION,
+};

--- a/packages/shortest/src/ai/tools/custom/check_email.ts
+++ b/packages/shortest/src/ai/tools/custom/check_email.ts
@@ -1,0 +1,14 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { BrowserTool } from "@/browser/core/browser-tool";
+
+export const createCheckEmailTool = (browserTool: BrowserTool) =>
+  tool({
+    description: "View received email in new browser tab",
+    parameters: z.object({
+      action: z.literal("check_email"),
+      email: z.string().describe("Email content or address to check for"),
+    }),
+    execute: browserTool.execute.bind(browserTool),
+    experimental_toToolResultContent: browserTool.resultToToolResultContent,
+  });

--- a/packages/shortest/src/ai/tools/custom/github_login.ts
+++ b/packages/shortest/src/ai/tools/custom/github_login.ts
@@ -1,0 +1,15 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { BrowserTool } from "@/browser/core/browser-tool";
+
+export const createGithubLoginTool = (browserTool: BrowserTool) =>
+  tool({
+    description: "Handle GitHub OAuth login with 2FA",
+    parameters: z.object({
+      action: z.literal("github_login"),
+      username: z.string(),
+      password: z.string(),
+    }),
+    execute: browserTool.execute.bind(browserTool),
+    experimental_toToolResultContent: browserTool.resultToToolResultContent,
+  });

--- a/packages/shortest/src/ai/tools/custom/navigate.ts
+++ b/packages/shortest/src/ai/tools/custom/navigate.ts
@@ -1,0 +1,14 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { BrowserTool } from "@/browser/core/browser-tool";
+
+export const createNavigateTool = (browserTool: BrowserTool) =>
+  tool({
+    description: "Navigate to URLs in new browser tab",
+    parameters: z.object({
+      action: z.literal("navigate"),
+      url: z.string().url().describe("The URL to navigate to"),
+    }),
+    execute: browserTool.execute.bind(browserTool),
+    experimental_toToolResultContent: browserTool.resultToToolResultContent,
+  });

--- a/packages/shortest/src/ai/tools/custom/run_callback.ts
+++ b/packages/shortest/src/ai/tools/custom/run_callback.ts
@@ -1,0 +1,13 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { BrowserTool } from "@/browser/core/browser-tool";
+
+export const createRunCallbackTool = (browserTool: BrowserTool) =>
+  tool({
+    description: "Run callback function for current test step",
+    parameters: z.object({
+      action: z.literal("run_callback"),
+    }),
+    execute: browserTool.execute.bind(browserTool),
+    experimental_toToolResultContent: browserTool.resultToToolResultContent,
+  });

--- a/packages/shortest/src/ai/tools/custom/sleep.ts
+++ b/packages/shortest/src/ai/tools/custom/sleep.ts
@@ -1,0 +1,14 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { BrowserTool } from "@/browser/core/browser-tool";
+
+export const createSleepTool = (browserTool: BrowserTool) =>
+  tool({
+    description: "Pause test execution for specified duration",
+    parameters: z.object({
+      action: z.literal("sleep"),
+      duration: z.number().min(0).max(60000),
+    }),
+    execute: browserTool.execute.bind(browserTool),
+    experimental_toToolResultContent: browserTool.resultToToolResultContent,
+  });

--- a/packages/shortest/src/browser/core/browser-tool.ts
+++ b/packages/shortest/src/browser/core/browser-tool.ts
@@ -614,6 +614,32 @@ export class BrowserTool extends BaseBrowserTool {
     }
   }
 
+  /**
+   * Converts browser tool execution results to standardized content format.
+   * Handles image data and text output formatting.
+   *
+   * @param {ToolResult} result - Raw tool execution result
+   * @returns {Array<{type: string, data?: string, text?: string, mimeType?: string}>} Formatted content
+   *
+   * @private
+   */
+  public resultToToolResultContent(result: ToolResult) {
+    return result.base64_image
+      ? [
+          {
+            type: "image" as const,
+            data: result.base64_image,
+            mimeType: "image/jpeg",
+          },
+        ]
+      : [
+          {
+            type: "text" as const,
+            text: result.output!,
+          },
+        ];
+  }
+
   private async getMetadata(): Promise<any> {
     const metadata: any = {
       window_info: {},

--- a/packages/shortest/src/core/runner/index.ts
+++ b/packages/shortest/src/core/runner/index.ts
@@ -18,7 +18,7 @@ import { getLogger, Log } from "@/log";
 import {
   TestFunction,
   TestContext,
-  BrowserActionEnum,
+  InternalActionEnum,
   ShortestStrictConfig,
 } from "@/types";
 import { TokenUsageSchema } from "@/types/ai";
@@ -29,12 +29,12 @@ import {
   asShortestError,
 } from "@/utils/errors";
 
-const TestStatusSchema = z.enum(["pending", "running", "passed", "failed"]);
-export type TestStatus = z.infer<typeof TestStatusSchema>;
+const testStatusSchema = z.enum(["pending", "running", "passed", "failed"]);
+export type TestStatus = z.infer<typeof testStatusSchema>;
 
 export const TestResultSchema = z.object({
   test: z.any() as z.ZodType<TestFunction>,
-  status: TestStatusSchema,
+  status: testStatusSchema,
   reason: z.string(),
   tokenUsage: TokenUsageSchema,
 });
@@ -42,7 +42,7 @@ export type TestResult = z.infer<typeof TestResultSchema>;
 
 export const FileResultSchema = z.object({
   filePath: z.string(),
-  status: TestStatusSchema,
+  status: testStatusSchema,
   reason: z.string(),
 });
 export type FileResult = z.infer<typeof FileResultSchema>;
@@ -472,7 +472,7 @@ export class TestRunner {
         ?.filter(
           (step) =>
             step.action?.input.action !==
-            BrowserActionEnum.Screenshot.toString(),
+            InternalActionEnum.SCREENSHOT.toString(),
         );
 
       if (!steps || steps.length === 0) {
@@ -483,7 +483,7 @@ export class TestRunner {
       for (const step of steps) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         if (
-          step.action?.input.action === BrowserActionEnum.MouseMove &&
+          step.action?.input.action === InternalActionEnum.MOUSE_MOVE &&
           // @ts-expect-error Interface and actual values differ
           step.action.input.coordinate
         ) {

--- a/packages/shortest/src/tools/index.ts
+++ b/packages/shortest/src/tools/index.ts
@@ -29,6 +29,13 @@ const toolToRegisterSchema = z.union([
 ]);
 type ToolToRegister = z.infer<typeof toolToRegisterSchema>;
 
+/**
+ * Creates and configures a new ToolRegistry with all available tools
+ *
+ * @returns Configured ToolRegistry instance with all tools registered
+ *
+ * @private
+ */
 export const createToolRegistry = (): ToolRegistry => {
   const toolRegistry = new ToolRegistry();
   const toolsToRegister: Record<string, ToolToRegister> = {

--- a/packages/shortest/src/tools/index.ts
+++ b/packages/shortest/src/tools/index.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import { createAnthropicBash20241022 } from "@/ai/tools/anthropic/bash_20241022";
+import { createAnthropicComputer20241022 } from "@/ai/tools/anthropic/computer_20241022";
+import { createCheckEmailTool } from "@/ai/tools/custom/check_email";
+import { createGithubLoginTool } from "@/ai/tools/custom/github_login";
+import { createNavigateTool } from "@/ai/tools/custom/navigate";
+import { createRunCallbackTool } from "@/ai/tools/custom/run_callback";
+import { createSleepTool } from "@/ai/tools/custom/sleep";
+import {
+  anthropicToolTypeSchema,
+  toolFactorySchema,
+  ToolRegistry,
+} from "@/tools/tool-registry";
+
+export { ToolRegistry };
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const toolToRegisterSchema = z.union([
+  z.object({
+    name: anthropicToolTypeSchema,
+    category: z.literal("provider"),
+    factory: toolFactorySchema,
+  }),
+  z.object({
+    name: z.string(),
+    category: z.literal("custom"),
+    factory: toolFactorySchema,
+  }),
+]);
+type ToolToRegister = z.infer<typeof toolToRegisterSchema>;
+
+export const createToolRegistry = (): ToolRegistry => {
+  const toolRegistry = new ToolRegistry();
+  const toolsToRegister: Record<string, ToolToRegister> = {
+    anthropic_computer_20241022: {
+      name: "computer",
+      category: "provider",
+      factory: createAnthropicComputer20241022,
+    },
+    anthropic_bash_20241022: {
+      name: "bash",
+      category: "provider",
+      factory: createAnthropicBash20241022,
+    },
+    check_email: {
+      name: "check_email",
+      category: "custom",
+      factory: createCheckEmailTool,
+    },
+    github_login: {
+      name: "github_login",
+      category: "custom",
+      factory: createGithubLoginTool,
+    },
+    navigate: {
+      name: "navigate",
+      category: "custom",
+      factory: createNavigateTool,
+    },
+    run_callback: {
+      name: "run_callback",
+      category: "custom",
+      factory: createRunCallbackTool,
+    },
+    sleep: {
+      name: "sleep",
+      category: "custom",
+      factory: createSleepTool,
+    },
+  };
+  Object.entries(toolsToRegister).forEach(([key, value]) => {
+    toolRegistry.registerTool(key, value);
+  });
+  return toolRegistry;
+};

--- a/packages/shortest/src/tools/tool-registry.ts
+++ b/packages/shortest/src/tools/tool-registry.ts
@@ -1,0 +1,164 @@
+import { Tool } from "ai";
+import { z } from "zod";
+import { BrowserTool } from "@/browser/core/browser-tool";
+import { getLogger, Log } from "@/log";
+import { AnthropicModel } from "@/types/config";
+import { ShortestError } from "@/utils/errors";
+const toolFactoryWithArgSchema = z
+  .function()
+  .args(z.custom<BrowserTool>())
+  .returns(z.custom<Tool>());
+
+export const TOOL_ENTRY_CATEGORIES = ["provider", "custom"] as const;
+const toolEntryCategorySchema = z.enum(TOOL_ENTRY_CATEGORIES);
+const toolFactoryNoArgSchema = z.function().args().returns(z.custom<Tool>());
+export const toolFactorySchema = z.union([
+  toolFactoryWithArgSchema,
+  toolFactoryNoArgSchema,
+]);
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const toolEntrySchema = z.union([
+  z.object({
+    name: z.literal("bash"),
+    category: z.literal("provider"),
+    factory: toolFactoryNoArgSchema,
+  }),
+  z.object({
+    name: z.string(),
+    category: toolEntryCategorySchema,
+    factory: toolFactoryWithArgSchema,
+  }),
+]);
+export type ToolEntry = z.infer<typeof toolEntrySchema>;
+
+export const anthropicToolTypeSchema = z.enum(["computer", "bash"]);
+export type AnthropicToolType = z.infer<typeof anthropicToolTypeSchema>;
+
+// eslint-disable-next-line zod/require-zod-schema-types
+export type AnthropicModelFamily = "claude-3-5";
+
+// eslint-disable-next-line zod/require-zod-schema-types
+export type AnthropicToolVersion = "20241022";
+
+const ANTHROPIC_MODEL_TO_FAMILY: Record<AnthropicModel, AnthropicModelFamily> =
+  {
+    "claude-3-5-sonnet-latest": "claude-3-5",
+    "claude-3-5-sonnet-20241022": "claude-3-5",
+  };
+
+const ANTHROPIC_TOOL_VERSION_MAP: Record<
+  AnthropicModelFamily,
+  Record<AnthropicToolType, AnthropicToolVersion>
+> = {
+  "claude-3-5": {
+    computer: "20241022",
+    bash: "20241022",
+  },
+};
+
+export class ToolRegistry {
+  private tools: Map<string, ToolEntry> = new Map();
+  private log: Log;
+
+  constructor() {
+    this.log = getLogger();
+  }
+
+  public registerTool(key: string, entry: ToolEntry) {
+    if (this.tools.has(key)) {
+      throw new Error(`Tool with key '${key}' already registered`);
+    }
+    this.tools.set(key, entry);
+  }
+
+  public getTools(
+    provider: string,
+    model: AnthropicModel,
+    browserTool: BrowserTool,
+  ): Record<string, Tool> {
+    const selectedTools: Record<string, Tool> = {};
+
+    const providerTools = this.getProviderTools(provider, model, browserTool);
+    const customTools = this.getCustomTools(browserTool);
+
+    Object.assign(selectedTools, providerTools, customTools);
+
+    this.tools.forEach((entry, key) => {
+      if (!key.startsWith(`${provider}_`)) {
+        selectedTools[entry.name] = entry.factory(browserTool);
+      }
+    });
+
+    return selectedTools;
+  }
+
+  private getCustomTools(browserTool: BrowserTool): Record<string, Tool> {
+    const tools: Record<string, Tool> = {};
+
+    const customTools = Array.from(this.tools.values()).filter(
+      (entry) => entry.category === "custom",
+    );
+    customTools.forEach((entry) => {
+      tools[entry.name] = entry.factory(browserTool);
+    });
+
+    return tools;
+  }
+
+  private getProviderTools(
+    provider: string,
+    model: AnthropicModel,
+    browserTool: BrowserTool,
+  ): Record<string, Tool> {
+    const tools: Record<string, Tool> = {};
+
+    try {
+      const computerToolEntry = this.getProviderToolEntry(
+        provider,
+        model,
+        "computer",
+      );
+      tools[computerToolEntry.name] = computerToolEntry.factory(browserTool);
+    } catch (error) {
+      if (!(error instanceof ShortestError)) throw error;
+      this.log.trace("Computer tool not found for model, skipping", { model });
+    }
+
+    try {
+      const bashToolEntry = this.getProviderToolEntry(provider, model, "bash");
+      // @ts-ignore
+      // For some reason, it expects an argument, but it doesn't take any
+      tools["bash"] = bashToolEntry.factory();
+    } catch (error) {
+      if (!(error instanceof ShortestError)) throw error;
+      this.log.trace("Bash tool not found for model, skipping", { model });
+    }
+
+    return tools;
+  }
+
+  private getProviderToolEntry(
+    provider: string,
+    model: AnthropicModel,
+    toolType: AnthropicToolType,
+  ): ToolEntry {
+    const toolEntryKey = this.getToolEntryKey(provider, model, toolType);
+    const toolEntry = this.tools.get(toolEntryKey);
+    if (toolEntry) {
+      return toolEntry;
+    }
+    throw new ShortestError(
+      `${toolType} tool not found for key: ${toolEntryKey}`,
+    );
+  }
+
+  private getToolEntryKey(
+    provider: string,
+    model: AnthropicModel,
+    toolType: AnthropicToolType,
+  ): string {
+    const family = ANTHROPIC_MODEL_TO_FAMILY[model];
+    const version = ANTHROPIC_TOOL_VERSION_MAP[family][toolType];
+    return `${provider}_${toolType}_${version}`;
+  }
+}

--- a/packages/shortest/src/types/browser.ts
+++ b/packages/shortest/src/types/browser.ts
@@ -13,27 +13,27 @@ export interface BrowserToolInterface {
   getPage(): Page;
 }
 
-export enum BrowserActionEnum {
-  MouseMove = "mouse_move",
-  LeftClick = "left_click",
-  LeftClickDrag = "left_click_drag",
-  RightClick = "right_click",
-  MiddleClick = "middle_click",
-  DoubleClick = "double_click",
-  Screenshot = "screenshot",
-  CursorPosition = "cursor_position",
-  GithubLogin = "github_login",
-  ClearSession = "clear_session",
-  Type = "type",
-  Key = "key",
-  RunCallback = "run_callback",
-  Navigate = "navigate",
-  Sleep = "sleep",
-  CheckMail = "check_email",
+export enum InternalActionEnum {
+  MOUSE_MOVE = "mouse_move",
+  LEFT_CLICK = "left_click",
+  LEFT_CLICK_DRAG = "left_click_drag",
+  RIGHT_CLICK = "right_click",
+  MIDDLE_CLICK = "middle_click",
+  DOUBLE_CLICK = "double_click",
+  SCREENSHOT = "screenshot",
+  CURSOR_POSITION = "cursor_position",
+  GITHUB_LOGIN = "github_login",
+  CLEAR_SESSION = "clear_session",
+  TYPE = "type",
+  KEY = "key",
+  RUN_CALLBACK = "run_callback",
+  NAVIGATE = "navigate",
+  SLEEP = "sleep",
+  CHECK_EMAIL = "check_email",
 }
 
 // eslint-disable-next-line zod/require-zod-schema-types
-export type BrowserAction = `${BrowserActionEnum}`;
+export type BrowserAction = `${InternalActionEnum}`;
 
 export interface BrowserToolOptions {
   width: number;

--- a/packages/shortest/src/types/config.ts
+++ b/packages/shortest/src/types/config.ts
@@ -8,7 +8,18 @@ export const cliOptionsSchema = z.object({
 });
 export type CLIOptions = z.infer<typeof cliOptionsSchema>;
 
-const ANTHROPIC_MODELS = ["claude-3-5-sonnet-20241022"] as const;
+/**
+ * List of Anthropic models that are supported by the AI client.
+ *
+ * @see https://sdk.vercel.ai/providers/ai-sdk-providers/anthropic#model-capabilities
+ * @see https://docs.anthropic.com/en/docs/about-claude/models/all-models
+ */
+export const ANTHROPIC_MODELS = [
+  "claude-3-5-sonnet-20241022",
+  "claude-3-5-sonnet-latest",
+] as const;
+export const anthropicModelSchema = z.enum(ANTHROPIC_MODELS);
+export type AnthropicModel = z.infer<typeof anthropicModelSchema>;
 
 const aiSchema = z
   .object({

--- a/packages/shortest/tests/unit/config.test.ts
+++ b/packages/shortest/tests/unit/config.test.ts
@@ -186,7 +186,7 @@ describe("Config parsing", () => {
           ai: { ...baseConfig.ai, model: "invalid-model" as any },
         };
         expect(() => parseConfig(userConfig)).toThrowError(
-          /Invalid shortest\.config\n(?:\u001b\[\d+m)?ai\.model(?:\u001b\[\d+m)?: Invalid enum value\. Expected 'claude-3-5-sonnet-20241022', received 'invalid-model'(?:\s\(received: "invalid-model"\))?/,
+          /Invalid shortest\.config\n(?:\u001b\[\d+m)?ai\.model(?:\u001b\[\d+m)?: Invalid enum value\. Expected 'claude-3-5-sonnet-20241022' | 'claude-3-5-sonnet-latest', received 'invalid-model'(?:\s\(received: "invalid-model"\))?/,
         );
       });
     });

--- a/packages/shortest/tests/unit/tools/index.test.ts
+++ b/packages/shortest/tests/unit/tools/index.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAnthropicBash20241022 } from "@/ai/tools/anthropic/bash_20241022";
+import { createAnthropicComputer20241022 } from "@/ai/tools/anthropic/computer_20241022";
+import { createCheckEmailTool } from "@/ai/tools/custom/check_email";
+import { createGithubLoginTool } from "@/ai/tools/custom/github_login";
+import { createNavigateTool } from "@/ai/tools/custom/navigate";
+import { createRunCallbackTool } from "@/ai/tools/custom/run_callback";
+import { createSleepTool } from "@/ai/tools/custom/sleep";
+import { BrowserTool } from "@/browser/core/browser-tool";
+import { createToolRegistry } from "@/tools/index";
+
+describe("tools/index", () => {
+  describe("createToolRegistry", () => {
+    it("creates a registry with all expected tools", () => {
+      const registry = createToolRegistry();
+
+      const mockBrowserTool = {
+        execute: vi.fn().mockResolvedValue({}),
+        resultToToolResultContent: vi.fn(),
+      } as unknown as BrowserTool;
+
+      const tools = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-latest",
+        mockBrowserTool,
+      );
+
+      expect(tools).toHaveProperty("computer");
+      expect(tools).toHaveProperty("bash");
+      expect(tools).toHaveProperty("check_email");
+      expect(tools).toHaveProperty("github_login");
+      expect(tools).toHaveProperty("navigate");
+      expect(tools).toHaveProperty("run_callback");
+      expect(tools).toHaveProperty("sleep");
+
+      const expectedToolCount = 7; // 2 provider tools + 5 custom tools
+      expect(Object.keys(tools).length).toBe(expectedToolCount);
+
+      const toolsMap = (registry as any).tools as Map<string, any>;
+
+      const computerTool = toolsMap.get("anthropic_computer_20241022");
+      expect(computerTool).toEqual({
+        name: "computer",
+        category: "provider",
+        factory: createAnthropicComputer20241022,
+      });
+
+      const bashTool = toolsMap.get("anthropic_bash_20241022");
+      expect(bashTool).toEqual({
+        name: "bash",
+        category: "provider",
+        factory: createAnthropicBash20241022,
+      });
+
+      const checkEmailTool = toolsMap.get("check_email");
+      expect(checkEmailTool).toEqual({
+        name: "check_email",
+        category: "custom",
+        factory: createCheckEmailTool,
+      });
+
+      const githubLoginTool = toolsMap.get("github_login");
+      expect(githubLoginTool).toEqual({
+        name: "github_login",
+        category: "custom",
+        factory: createGithubLoginTool,
+      });
+
+      const navigateTool = toolsMap.get("navigate");
+      expect(navigateTool).toEqual({
+        name: "navigate",
+        category: "custom",
+        factory: createNavigateTool,
+      });
+
+      const runCallbackTool = toolsMap.get("run_callback");
+      expect(runCallbackTool).toEqual({
+        name: "run_callback",
+        category: "custom",
+        factory: createRunCallbackTool,
+      });
+
+      const sleepTool = toolsMap.get("sleep");
+      expect(sleepTool).toEqual({
+        name: "sleep",
+        category: "custom",
+        factory: createSleepTool,
+      });
+    });
+
+    it("provides tools with execute functionality", () => {
+      const registry = createToolRegistry();
+
+      const mockBrowserTool = {
+        execute: vi.fn().mockResolvedValue({}),
+        resultToToolResultContent: vi.fn(),
+      } as unknown as BrowserTool;
+
+      const tools = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-latest",
+        mockBrowserTool,
+      );
+
+      Object.values(tools).forEach((tool) => {
+        expect(tool).toHaveProperty("execute");
+
+        expect(typeof tool.execute).toBe("function");
+      });
+    });
+
+    it("registers tools with expected keys", () => {
+      const registry = createToolRegistry();
+
+      const toolsMap = (registry as any).tools as Map<string, any>;
+
+      expect(toolsMap.has("anthropic_computer_20241022")).toBe(true);
+      expect(toolsMap.has("anthropic_bash_20241022")).toBe(true);
+      expect(toolsMap.has("check_email")).toBe(true);
+      expect(toolsMap.has("github_login")).toBe(true);
+      expect(toolsMap.has("navigate")).toBe(true);
+      expect(toolsMap.has("run_callback")).toBe(true);
+      expect(toolsMap.has("sleep")).toBe(true);
+
+      expect(toolsMap.size).toBe(7);
+    });
+  });
+});

--- a/packages/shortest/tests/unit/tools/tool-registry.test.ts
+++ b/packages/shortest/tests/unit/tools/tool-registry.test.ts
@@ -143,36 +143,6 @@ describe("ToolRegistry", () => {
       expect(Object.keys(tools).length).toBe(3);
     });
 
-    it("includes non-provider tools regardless of provider", () => {
-      const otherProviderToolEntry = {
-        name: "otherProvider",
-        category: "provider" as const,
-        factory: (_browserTool: BrowserTool) => createMockTool("otherProvider"),
-      };
-
-      registry.registerTool("other_computer_20241022", otherProviderToolEntry);
-
-      const correctProviderToolEntry = {
-        name: "computer",
-        category: "provider" as const,
-        factory: (_browserTool: BrowserTool) => createMockTool("computer"),
-      };
-
-      registry.registerTool(
-        "anthropic_computer_20241022",
-        correctProviderToolEntry,
-      );
-
-      const tools = registry.getTools(
-        "anthropic",
-        "claude-3-5-sonnet-latest",
-        mockBrowserTool,
-      );
-
-      expect(tools).toHaveProperty("computer");
-      expect(tools).toHaveProperty("otherProvider");
-    });
-
     it("handles missing provider tools gracefully", () => {
       const customToolEntry = {
         name: "customTool",

--- a/packages/shortest/tests/unit/tools/tool-registry.test.ts
+++ b/packages/shortest/tests/unit/tools/tool-registry.test.ts
@@ -1,0 +1,246 @@
+import { Tool } from "ai";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { z } from "zod";
+import { BrowserTool } from "@/browser/core/browser-tool";
+import { ToolRegistry } from "@/tools/tool-registry";
+import { ShortestError } from "@/utils/errors";
+
+describe("ToolRegistry", () => {
+  let registry: ToolRegistry;
+  let mockBrowserTool: BrowserTool;
+
+  const createMockTool = (name: string): Tool =>
+    ({
+      parameters: z.object({}),
+      description: `Mock ${name} tool`,
+      execute: vi.fn().mockResolvedValue(`Executed ${name}`),
+      __meta: { name },
+    }) as unknown as Tool;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+
+    mockBrowserTool = {} as BrowserTool;
+  });
+
+  describe("registerTool", () => {
+    it("registers a tool successfully", () => {
+      const toolEntry = {
+        name: "mockTool",
+        category: "custom" as const,
+        factory: (_browserTool: BrowserTool) => createMockTool("mockTool"),
+      };
+
+      registry.registerTool("mock_tool", toolEntry);
+
+      const tools = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-latest",
+        mockBrowserTool,
+      );
+      expect(tools).toHaveProperty("mockTool");
+    });
+
+    it("throws an error when registering a duplicate tool", () => {
+      const toolEntry = {
+        name: "mockTool",
+        category: "custom" as const,
+        factory: (_browserTool: BrowserTool) => createMockTool("mockTool"),
+      };
+
+      registry.registerTool("mock_tool", toolEntry);
+
+      expect(() => {
+        registry.registerTool("mock_tool", toolEntry);
+      }).toThrow("Tool with key 'mock_tool' already registered");
+    });
+  });
+
+  describe("getTools", () => {
+    it("returns custom tools", () => {
+      const customToolEntry = {
+        name: "customTool",
+        category: "custom" as const,
+        factory: (_browserTool: BrowserTool) => createMockTool("customTool"),
+      };
+
+      registry.registerTool("custom_tool", customToolEntry);
+
+      const tools = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-latest",
+        mockBrowserTool,
+      );
+      expect(tools).toHaveProperty("customTool");
+    });
+
+    it("returns provider tools", () => {
+      const computerToolEntry = {
+        name: "computer",
+        category: "provider" as const,
+        factory: (_browserTool: BrowserTool) => createMockTool("computer"),
+      };
+
+      registry.registerTool("anthropic_computer_20241022", computerToolEntry);
+
+      const tools = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-latest",
+        mockBrowserTool,
+      );
+      expect(tools).toHaveProperty("computer");
+    });
+
+    it("returns bash tool without requiring browserTool argument", () => {
+      const bashToolEntry = {
+        name: "bash",
+        category: "provider" as const,
+        factory: () => createMockTool("bash"),
+      };
+
+      registry.registerTool("anthropic_bash_20241022", bashToolEntry);
+
+      const tools = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-latest",
+        mockBrowserTool,
+      );
+      expect(tools).toHaveProperty("bash");
+    });
+
+    it("combines provider and custom tools", () => {
+      const customToolEntry = {
+        name: "customTool",
+        category: "custom" as const,
+        factory: (_browserTool: BrowserTool) => createMockTool("customTool"),
+      };
+
+      const providerToolEntry = {
+        name: "computer",
+        category: "provider" as const,
+        factory: (_browserTool: BrowserTool) => createMockTool("computer"),
+      };
+
+      const bashToolEntry = {
+        name: "bash",
+        category: "provider" as const,
+        factory: () => createMockTool("bash"),
+      };
+
+      registry.registerTool("custom_tool", customToolEntry);
+      registry.registerTool("anthropic_computer_20241022", providerToolEntry);
+      registry.registerTool("anthropic_bash_20241022", bashToolEntry);
+
+      const tools = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-latest",
+        mockBrowserTool,
+      );
+
+      expect(tools).toHaveProperty("customTool");
+      expect(tools).toHaveProperty("computer");
+      expect(tools).toHaveProperty("bash");
+      expect(Object.keys(tools).length).toBe(3);
+    });
+
+    it("includes non-provider tools regardless of provider", () => {
+      const otherProviderToolEntry = {
+        name: "otherProvider",
+        category: "provider" as const,
+        factory: (_browserTool: BrowserTool) => createMockTool("otherProvider"),
+      };
+
+      registry.registerTool("other_computer_20241022", otherProviderToolEntry);
+
+      const correctProviderToolEntry = {
+        name: "computer",
+        category: "provider" as const,
+        factory: (_browserTool: BrowserTool) => createMockTool("computer"),
+      };
+
+      registry.registerTool(
+        "anthropic_computer_20241022",
+        correctProviderToolEntry,
+      );
+
+      const tools = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-latest",
+        mockBrowserTool,
+      );
+
+      expect(tools).toHaveProperty("computer");
+      expect(tools).toHaveProperty("otherProvider");
+    });
+
+    it("handles missing provider tools gracefully", () => {
+      const customToolEntry = {
+        name: "customTool",
+        category: "custom" as const,
+        factory: (_browserTool: BrowserTool) => createMockTool("customTool"),
+      };
+
+      registry.registerTool("custom_tool", customToolEntry);
+
+      const tools = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-latest",
+        mockBrowserTool,
+      );
+
+      expect(tools).toHaveProperty("customTool");
+      expect(Object.keys(tools).length).toBe(1);
+    });
+
+    it("respects model-specific tool versions", () => {
+      const computerToolLatest = {
+        name: "computer",
+        category: "provider" as const,
+        factory: (_browserTool: BrowserTool) =>
+          createMockTool("computer-latest"),
+      };
+
+      registry.registerTool("anthropic_computer_20241022", computerToolLatest);
+
+      const toolsLatest = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-latest",
+        mockBrowserTool,
+      );
+      const toolsFixed = registry.getTools(
+        "anthropic",
+        "claude-3-5-sonnet-20241022",
+        mockBrowserTool,
+      );
+
+      expect(toolsLatest).toHaveProperty("computer");
+      expect(toolsFixed).toHaveProperty("computer");
+    });
+  });
+
+  describe("getProviderToolEntry", () => {
+    it("throws ShortestError when tool not found", () => {
+      const getProviderToolEntry = (registry as any).getProviderToolEntry.bind(
+        registry,
+      );
+
+      expect(() => {
+        getProviderToolEntry(
+          "anthropic",
+          "claude-3-5-sonnet-latest",
+          "computer",
+        );
+      }).toThrow(ShortestError);
+
+      expect(() => {
+        getProviderToolEntry(
+          "anthropic",
+          "claude-3-5-sonnet-latest",
+          "computer",
+        );
+      }).toThrow(
+        "computer tool not found for key: anthropic_computer_20241022",
+      );
+    });
+  });
+});


### PR DESCRIPTION
### What

Implement a comprehensive refactoring of the AI tools system  

* Create a modular tool system with a central ToolRegistry class
* Move tools from hardcoded implementation in AIClient to dedicated files
* Implement tool registration through createToolRegistry()
* Map Anthropic's computer actions to internal actions

### Why

In preparation for adding Claude 3.7.

Ref https://github.com/anti-work/shortest/pull/369#issuecomment-2691388346