### PR TITLE
feat: add config.browser options

### DIFF
--- a/packages/shortest/src/browser/manager/index.ts
+++ b/packages/shortest/src/browser/manager/index.ts
@@ -54,10 +54,13 @@ export class BrowserManager {
       }
     }
 
-    this.context = await this.browser.newContext({
+    const contextOptions = {
       viewport: { width: 1920, height: 1080 },
       baseURL: this.config.baseUrl,
-    });
+      ...this.config.browser?.contextOptions,
+    };
+    this.log.trace("Initializing browser context", { options: contextOptions });
+    this.context = await this.browser.newContext(contextOptions);
 
     const page = await this.context.newPage();
     await page.goto(this.normalizeUrl(this.config.baseUrl));

--- a/packages/shortest/src/types/config.ts
+++ b/packages/shortest/src/types/config.ts
@@ -1,3 +1,4 @@
+import { BrowserContextOptions } from "playwright";
 import { z } from "zod";
 
 export const cliOptionsSchema = z.object({
@@ -41,10 +42,18 @@ const mailosaurSchema = z
 
 const testPatternSchema = z.string().default("**/*.test.ts");
 
+const browserSchema = z.object({
+  /**
+   * @see https://playwright.dev/docs/api/class-browser#browser-new-context
+   */
+  contextOptions: z.custom<BrowserContextOptions>().optional(),
+});
+
 export const configSchema = z
   .object({
     headless: z.boolean().default(true),
     baseUrl: z.string().url("must be a valid URL"),
+    browser: browserSchema.strict().partial().default(browserSchema.parse({})),
     testPattern: testPatternSchema,
     anthropicKey: z.string().optional(),
     ai: aiSchema,
@@ -54,6 +63,7 @@ export const configSchema = z
   .strict();
 
 export const userConfigSchema = configSchema.extend({
+  browser: browserSchema.optional(),
   testPattern: testPatternSchema.optional(),
   ai: aiSchema.strict().partial().optional(),
   caching: cachingSchema.strict().partial().optional(),

--- a/packages/shortest/tests/unit/config.test.ts
+++ b/packages/shortest/tests/unit/config.test.ts
@@ -21,12 +21,14 @@ describe("Config parsing", () => {
       expect(Object.keys(config)).toEqual([
         "headless",
         "baseUrl",
+        "browser",
         "testPattern",
         "ai",
         "caching",
       ]);
       expect(config.headless).toBe(true);
       expect(config.baseUrl).toBe("https://example.com");
+      expect(config.browser).toEqual({});
       expect(config.testPattern).toBe("**/*.test.ts");
       expect(config.ai).toEqual({
         apiKey: "foo",
@@ -49,6 +51,35 @@ describe("Config parsing", () => {
         apiKey: "explicit-api-key",
       },
     };
+  });
+
+  describe("with invalid config.browser option", () => {
+    test("it throws an error", () => {
+      const userConfig = {
+        ...baseConfig,
+        browser: {
+          invalidBrowserOption: "value",
+        },
+      } as any;
+      expect(() => parseConfig(userConfig)).toThrowError(
+        "Unrecognized key(s) in object: 'invalidBrowserOption'",
+      );
+    });
+  });
+
+  describe("with config.browser.contextOptions option", () => {
+    test("it passes through", () => {
+      const userConfig = {
+        ...baseConfig,
+        browser: {
+          contextOptions: { ignoreHTTPSErrors: true },
+        },
+      };
+      const config = parseConfig(userConfig);
+      expect(config.browser?.contextOptions).toEqual({
+        ignoreHTTPSErrors: true,
+      });
+    });
   });
 
   describe("with invalid config option", () => {

--- a/packages/shortest/tests/unit/initialize-config.test.ts
+++ b/packages/shortest/tests/unit/initialize-config.test.ts
@@ -36,6 +36,7 @@ describe("initializeConfig", () => {
     expect(config).toEqual({
       headless: true,
       baseUrl: "https://example.com",
+      browser: {},
       testPattern: ".*",
       ai: {
         provider: "anthropic",
@@ -70,6 +71,7 @@ describe("initializeConfig", () => {
     expect(config).toEqual({
       headless: true,
       baseUrl: "https://example.com",
+      browser: {},
       testPattern: ".*",
       ai: {
         provider: "anthropic",
@@ -154,6 +156,7 @@ describe("initializeConfig", () => {
       expect(config).toEqual({
         headless: true,
         baseUrl: "https://other.example.com",
+        browser: {},
         testPattern: "**/*.test.ts",
         ai: {
           provider: "anthropic",


### PR DESCRIPTION
Adds browser.contextOptions to pass custom [Playwright browser context options](https://playwright.dev/docs/test-use-options#more-browser-and-context-options).
* Allows configuring browser behavior (ignore HTTPS errors, permissions, geolocation)
* Apply options when initializing browser context
