### PR TITLE
fix(cli): execute test with line no functionality

### DIFF
--- a/packages/shortest/src/core/runner/test-file-parser.ts
+++ b/packages/shortest/src/core/runner/test-file-parser.ts
@@ -1,11 +1,14 @@
 import { readFileSync } from "fs";
 import * as parser from "@babel/parser";
 import type { NodePath } from "@babel/traverse";
-import traverse from "@babel/traverse";
 import type * as t from "@babel/types";
 import * as babelTypes from "@babel/types";
 import { z } from "zod";
 import { getLogger } from "@/log";
+import traverseDefault from "@babel/traverse";
+
+// @ts-ignore
+const traverse = traverseDefault.default;
 
 export const EXPRESSION_PLACEHOLDER = "${...}";
 
@@ -22,6 +25,12 @@ export const parseShortestTestFile = (filePath: string): TestLocation[] => {
   const log = getLogger();
   try {
     log.setGroup("File Parser");
+
+    log.info("Imported modules:", {
+      parser: parser != null ? "✅" : "❌",
+      traverse: traverse != null ? "✅" : "❌",
+      zod: z != null ? "✅" : "❌"
+    });
 
     const TemplateElementSchema = z.object({
       value: z.object({

--- a/packages/shortest/src/core/runner/test-file-parser.ts
+++ b/packages/shortest/src/core/runner/test-file-parser.ts
@@ -26,12 +26,15 @@ export const parseShortestTestFile = (filePath: string): TestLocation[] => {
   try {
     log.setGroup("File Parser");
 
+<<<<<<< Updated upstream
     log.info("Imported modules:", {
       parser: parser != null ? "✅" : "❌",
       traverse: traverse != null ? "✅" : "❌",
       zod: z != null ? "✅" : "❌",
     });
 
+=======
+>>>>>>> Stashed changes
     const TemplateElementSchema = z.object({
       value: z.object({
         cooked: z.string().optional(),

--- a/packages/shortest/src/core/runner/test-file-parser.ts
+++ b/packages/shortest/src/core/runner/test-file-parser.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from "fs";
 import * as parser from "@babel/parser";
 import type { NodePath } from "@babel/traverse";
+import traverseDefault from "@babel/traverse";
 import type * as t from "@babel/types";
 import * as babelTypes from "@babel/types";
 import { z } from "zod";
 import { getLogger } from "@/log";
-import traverseDefault from "@babel/traverse";
 
 // @ts-ignore
 const traverse = traverseDefault.default;
@@ -29,7 +29,7 @@ export const parseShortestTestFile = (filePath: string): TestLocation[] => {
     log.info("Imported modules:", {
       parser: parser != null ? "✅" : "❌",
       traverse: traverse != null ? "✅" : "❌",
-      zod: z != null ? "✅" : "❌"
+      zod: z != null ? "✅" : "❌",
     });
 
     const TemplateElementSchema = z.object({

--- a/packages/shortest/src/core/runner/test-file-parser.ts
+++ b/packages/shortest/src/core/runner/test-file-parser.ts
@@ -1,14 +1,14 @@
 import { readFileSync } from "fs";
+import { createRequire } from "module";
 import * as parser from "@babel/parser";
 import type { NodePath } from "@babel/traverse";
 import type * as t from "@babel/types";
 import * as babelTypes from "@babel/types";
 import { z } from "zod";
 import { getLogger } from "@/log";
-import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
-const traverse = require('@babel/traverse').default;
+const traverse = require("@babel/traverse").default;
 
 export const EXPRESSION_PLACEHOLDER = "${...}";
 

--- a/packages/shortest/src/core/runner/test-file-parser.ts
+++ b/packages/shortest/src/core/runner/test-file-parser.ts
@@ -1,14 +1,14 @@
 import { readFileSync } from "fs";
 import * as parser from "@babel/parser";
 import type { NodePath } from "@babel/traverse";
-import traverseDefault from "@babel/traverse";
 import type * as t from "@babel/types";
 import * as babelTypes from "@babel/types";
 import { z } from "zod";
 import { getLogger } from "@/log";
+import { createRequire } from 'module';
 
-// @ts-ignore
-const traverse = traverseDefault.default;
+const require = createRequire(import.meta.url);
+const traverse = require('@babel/traverse').default;
 
 export const EXPRESSION_PLACEHOLDER = "${...}";
 

--- a/packages/shortest/src/core/runner/test-file-parser.ts
+++ b/packages/shortest/src/core/runner/test-file-parser.ts
@@ -26,15 +26,6 @@ export const parseShortestTestFile = (filePath: string): TestLocation[] => {
   try {
     log.setGroup("File Parser");
 
-<<<<<<< Updated upstream
-    log.info("Imported modules:", {
-      parser: parser != null ? "✅" : "❌",
-      traverse: traverse != null ? "✅" : "❌",
-      zod: z != null ? "✅" : "❌",
-    });
-
-=======
->>>>>>> Stashed changes
     const TemplateElementSchema = z.object({
       value: z.object({
         cooked: z.string().optional(),


### PR DESCRIPTION
fix: #381 

@babel/traverse is a CommonJS module,
which is being imported into ESM, 
hence its exports structure becomes { default: { default: Function } }

We need to access the nested default export and use the commonjs require approach